### PR TITLE
Add user onboarding flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Styles (such as fonts or colors) should be stored centrally, to improve future s
 
 Always use Cupertino styling. Do not use Material unless there is no Cupertino alternative, and then in that case, get permission first. 
 
+For colors and fonts, use the existing ones that are already being used. 
+
 ## Database
 
 In the MCP-connected Supabase, use its schema and datatable for figuring out functionality that utilizes that server. 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,6 +12,8 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
   - Flutter (1.0.0)
+  - flutter_contacts (0.0.1):
+    - Flutter
   - flutter_localization (0.0.1):
     - Flutter
   - google_sign_in_ios (0.0.1):
@@ -42,6 +44,55 @@ PODS:
   - GTMSessionFetcher/Core (3.5.0)
   - GTMSessionFetcher/Full (3.5.0):
     - GTMSessionFetcher/Core
+  - onesignal_flutter (5.3.4):
+    - Flutter
+    - OneSignalXCFramework (= 5.4.0)
+  - OneSignalXCFramework (5.4.0):
+    - OneSignalXCFramework/OneSignalComplete (= 5.4.0)
+  - OneSignalXCFramework/OneSignal (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+    - OneSignalXCFramework/OneSignalExtension
+    - OneSignalXCFramework/OneSignalLiveActivities
+    - OneSignalXCFramework/OneSignalNotifications
+    - OneSignalXCFramework/OneSignalOSCore
+    - OneSignalXCFramework/OneSignalOutcomes
+    - OneSignalXCFramework/OneSignalUser
+  - OneSignalXCFramework/OneSignalComplete (5.4.0):
+    - OneSignalXCFramework/OneSignal
+    - OneSignalXCFramework/OneSignalInAppMessages
+    - OneSignalXCFramework/OneSignalLocation
+  - OneSignalXCFramework/OneSignalCore (5.4.0)
+  - OneSignalXCFramework/OneSignalExtension (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+    - OneSignalXCFramework/OneSignalOutcomes
+  - OneSignalXCFramework/OneSignalInAppMessages (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+    - OneSignalXCFramework/OneSignalNotifications
+    - OneSignalXCFramework/OneSignalOSCore
+    - OneSignalXCFramework/OneSignalOutcomes
+    - OneSignalXCFramework/OneSignalUser
+  - OneSignalXCFramework/OneSignalLiveActivities (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+    - OneSignalXCFramework/OneSignalOSCore
+    - OneSignalXCFramework/OneSignalUser
+  - OneSignalXCFramework/OneSignalLocation (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+    - OneSignalXCFramework/OneSignalNotifications
+    - OneSignalXCFramework/OneSignalOSCore
+    - OneSignalXCFramework/OneSignalUser
+  - OneSignalXCFramework/OneSignalNotifications (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+    - OneSignalXCFramework/OneSignalExtension
+    - OneSignalXCFramework/OneSignalOutcomes
+  - OneSignalXCFramework/OneSignalOSCore (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+  - OneSignalXCFramework/OneSignalOutcomes (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+  - OneSignalXCFramework/OneSignalUser (5.4.0):
+    - OneSignalXCFramework/OneSignalCore
+    - OneSignalXCFramework/OneSignalNotifications
+    - OneSignalXCFramework/OneSignalOSCore
+    - OneSignalXCFramework/OneSignalOutcomes
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -57,8 +108,10 @@ PODS:
 DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
   - Flutter (from `Flutter`)
+  - flutter_contacts (from `.symlinks/plugins/flutter_contacts/ios`)
   - flutter_localization (from `.symlinks/plugins/flutter_localization/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
+  - onesignal_flutter (from `.symlinks/plugins/onesignal_flutter/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
@@ -72,6 +125,7 @@ SPEC REPOS:
     - GoogleUtilities
     - GTMAppAuth
     - GTMSessionFetcher
+    - OneSignalXCFramework
     - PromisesObjC
 
 EXTERNAL SOURCES:
@@ -79,10 +133,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/app_links/ios"
   Flutter:
     :path: Flutter
+  flutter_contacts:
+    :path: ".symlinks/plugins/flutter_contacts/ios"
   flutter_localization:
     :path: ".symlinks/plugins/flutter_localization/ios"
   google_sign_in_ios:
     :path: ".symlinks/plugins/google_sign_in_ios/darwin"
+  onesignal_flutter:
+    :path: ".symlinks/plugins/onesignal_flutter/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   shared_preferences_foundation:
@@ -97,12 +155,15 @@ SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_contacts: 5383945387e7ca37cf963d4be57c21f2fc15ca9f
   flutter_localization: 72299fb6cb4e51cae587bd953ed0b958040b71e6
   google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  onesignal_flutter: 6822b73de41c2286b17b6e8af3924a0e9d236aff
+  OneSignalXCFramework: 95b6391df5a91b448003149c1a633ade42ceca1e
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSContactsUsageDescription</key>
+	<string>We use your contacts to invite household members.</string>
 </dict>
 </plist>

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,0 +1,10 @@
+class AppConfig {
+  static const String oneSignalAppId = 'REPLACE_WITH_ONESIGNAL_APP_ID';
+  static const bool enablePushNotifications = false;
+
+  // Developer testing overrides
+  static const bool enableDebugOverrides = true;
+  // Options: 'onboarding profile', 'onboarding invite', 'onboarding add members',
+  // 'onboarding contacts', 'onboarding invite sent', 'start'
+  static const String? debugOverridePage = 'onboarding profile';
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,13 @@ import 'start_screen.dart';
 import 'household_income_summary_screen.dart';
 import 'expenses_screen.dart';
 import 'summary_screen.dart';
+import 'onboarding_profile_screen.dart';
+import 'onboarding_invite_screen.dart';
+import 'onboarding_add_members_screen.dart';
+import 'onboarding_contacts_screen.dart';
+import 'onboarding_invite_sent_screen.dart';
+import 'styles/app_styles.dart';
+import 'config/app_config.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -58,6 +65,12 @@ class _AppInitGateState extends State<AppInitGate> {
         anonKey:
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Indmb3R5YnNydWx5Z2ZhdWNqY3BhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzgzMDkwMzQsImV4cCI6MjA1Mzg4NTAzNH0.kudmu74JQfGfQJ1_63tialCwtkPKOdg9XM08liuCpnk',
       );
+      if (AppConfig.enablePushNotifications) {
+        // OneSignal initialization (requires APNs setup). Keeping for future use.
+        // Example:
+        // OneSignal.initialize(AppConfig.oneSignalAppId);
+        // OneSignal.Notifications.requestPermission(true);
+      }
 
       appState.setSupabaseReady(true);
     } catch (e, stackTrace) {
@@ -88,27 +101,27 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     // Provider.of<AppState>(context, listen: false).updateBrightnessMode(context);
 
-    return Consumer<AppState>(builder: (context, appState, child) {
-      return CupertinoApp(
-        debugShowCheckedModeBanner: false,
-        localizationsDelegates: const [
-          GlobalMaterialLocalizations
-              .delegate, // <-- gives MaterialLocalizations
-          GlobalWidgetsLocalizations.delegate,
-          DefaultCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: const [
-          Locale('en', 'US'),
-        ],
-        title: 'Flutter Demo',
-        theme: CupertinoThemeData(
-          brightness: appState.brightnessModeSwitchValue
-              ? Brightness.dark
-              : Brightness.light,
-        ),
-        home: const AppInitGate(child: MyHomePage()),
-      );
-    });
+    return Consumer<AppState>(
+      builder: (context, appState, child) {
+        return CupertinoApp(
+          debugShowCheckedModeBanner: false,
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations
+                .delegate, // <-- gives MaterialLocalizations
+            GlobalWidgetsLocalizations.delegate,
+            DefaultCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [Locale('en', 'US')],
+          title: 'Flutter Demo',
+          theme: CupertinoThemeData(
+            brightness: appState.brightnessModeSwitchValue
+                ? Brightness.dark
+                : Brightness.light,
+          ),
+          home: const AppInitGate(child: MyHomePage()),
+        );
+      },
+    );
   }
 }
 
@@ -149,15 +162,27 @@ class MyHomePage extends StatelessWidget {
       case 'household income summary':
         screen = householdIncomeSummaryScreen();
         break;
+      case 'onboarding profile':
+        screen = onboardingProfileScreen();
+        break;
+      case 'onboarding invite':
+        screen = onboardingInviteScreen();
+        break;
+      case 'onboarding add members':
+        screen = onboardingAddMembersScreen();
+        break;
+      case 'onboarding contacts':
+        screen = onboardingContactsScreen();
+        break;
+      case 'onboarding invite sent':
+        screen = onboardingInviteSentScreen();
+        break;
       default:
         screen = logoScreen();
         break;
     }
 
-    return KeyedSubtree(
-      key: ValueKey(appState.currentPage),
-      child: screen,
-    );
+    return KeyedSubtree(key: ValueKey(appState.currentPage), child: screen);
   }
 
   @override
@@ -167,59 +192,61 @@ class MyHomePage extends StatelessWidget {
       'start',
       'expenses',
       'summary',
-      'household income summary'
+      'household income summary',
     ];
-    return Consumer<AppState>(builder: (context, appState, child) {
-      return CupertinoPageScaffold(
-        backgroundColor: Color(0xFFf9f5d2),
-        navigationBar: appState.showNavigationBar
-            ? CupertinoNavigationBar(
-                leading: Builder(
-                  builder: (BuildContext context) {
-                    IconData icon;
-                    if (flowPages.contains(appState.currentPage)) {
-                      icon = CupertinoIcons.bars;
-                    } else if (appState.currentPage == 'menu') {
-                      icon = CupertinoIcons.clear;
-                    } else if (appState.currentPage == 'config' ||
-                        appState.currentPage == 'exceptions') {
-                      icon = CupertinoIcons.back;
-                    } else {
-                      icon = CupertinoIcons.clear;
-                    }
-                    return CupertinoButton(
-                      padding: EdgeInsets.zero,
-                      child: Icon(icon),
-                      onPressed: () {
-                        appState.handleMenuButtonPressed(icon);
-                      },
-                    );
-                  },
-                ),
-              )
-            : null,
-        child: SafeArea(
-          minimum: const EdgeInsets.all(20.0),
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 500),
-                  transitionBuilder:
-                      (Widget child, Animation<double> animation) {
-                    return FadeTransition(
-                      opacity: animation,
-                      child: child,
-                    );
-                  },
-                  child: _buildCurrentPage(appState),
-                ),
-              ],
+    return Consumer<AppState>(
+      builder: (context, appState, child) {
+        return CupertinoPageScaffold(
+          backgroundColor: AppColors.cream,
+          navigationBar: appState.showNavigationBar
+              ? CupertinoNavigationBar(
+                  leading: Builder(
+                    builder: (BuildContext context) {
+                      IconData icon;
+                      if (flowPages.contains(appState.currentPage)) {
+                        icon = CupertinoIcons.bars;
+                      } else if (appState.currentPage == 'menu') {
+                        icon = CupertinoIcons.clear;
+                      } else if (appState.currentPage == 'config' ||
+                          appState.currentPage == 'exceptions') {
+                        icon = CupertinoIcons.back;
+                      } else {
+                        icon = CupertinoIcons.clear;
+                      }
+                      return CupertinoButton(
+                        padding: EdgeInsets.zero,
+                        child: Icon(icon),
+                        onPressed: () {
+                          appState.handleMenuButtonPressed(icon);
+                        },
+                      );
+                    },
+                  ),
+                )
+              : null,
+          child: SafeArea(
+            minimum: const EdgeInsets.all(20.0),
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 500),
+                    transitionBuilder:
+                        (Widget child, Animation<double> animation) {
+                          return FadeTransition(
+                            opacity: animation,
+                            child: child,
+                          );
+                        },
+                    child: _buildCurrentPage(appState),
+                  ),
+                ],
+              ),
             ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
   }
 }

--- a/lib/onboarding_add_members_screen.dart
+++ b/lib/onboarding_add_members_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+
+class OnboardingAddMembersScreen extends StatefulWidget {
+  const OnboardingAddMembersScreen({super.key});
+
+  @override
+  State<OnboardingAddMembersScreen> createState() =>
+      _OnboardingAddMembersScreenState();
+}
+
+class _OnboardingAddMembersScreenState
+    extends State<OnboardingAddMembersScreen> {
+  final TextEditingController _householdController = TextEditingController();
+  String? _errorText;
+
+  @override
+  void dispose() {
+    _householdController.dispose();
+    super.dispose();
+  }
+
+  void _continue(AppState appState) {
+    final name = _householdController.text.trim();
+    if (name.isEmpty) {
+      setState(() => _errorText = 'Please name your household.');
+      return;
+    }
+    setState(() => _errorText = null);
+    appState.setHouseholdName(name);
+    appState.navigateToPage('onboarding contacts');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(builder: (context, appState, child) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text('Welcome! Add members of your household',
+              style: AppText.headline()),
+          const SizedBox(height: AppSpacing.md),
+          CupertinoTextField(
+            controller: _householdController,
+            placeholder: 'Household name',
+            decoration: BoxDecoration(
+              color: CupertinoColors.white,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: AppColors.deepGreen, width: 2),
+            ),
+          ),
+          if (_errorText != null) ...[
+            const SizedBox(height: AppSpacing.sm),
+            Text(_errorText!, style: AppText.caption()),
+          ],
+          const SizedBox(height: AppSpacing.lg),
+          CupertinoButton.filled(
+            onPressed: appState.isBusy ? null : () => _continue(appState),
+            child: const Text('Import contacts'),
+          ),
+        ],
+      );
+    });
+  }
+}
+
+Widget onboardingAddMembersScreen() => const OnboardingAddMembersScreen();

--- a/lib/onboarding_contacts_screen.dart
+++ b/lib/onboarding_contacts_screen.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+import 'package:country_picker/country_picker.dart';
+import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+
+class OnboardingContactsScreen extends StatefulWidget {
+  const OnboardingContactsScreen({super.key});
+
+  @override
+  State<OnboardingContactsScreen> createState() =>
+      _OnboardingContactsScreenState();
+}
+
+class _OnboardingContactsScreenState extends State<OnboardingContactsScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  final TextEditingController _manualNameController = TextEditingController();
+  final TextEditingController _manualPhoneController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<AppState>().loadContacts();
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _manualNameController.dispose();
+    _manualPhoneController.dispose();
+    super.dispose();
+  }
+
+  void _showCountryPicker(BuildContext context, AppState appState) {
+    showCountryPicker(
+      context: context,
+      onSelect: (country) => appState.setSelectedCountry(country),
+    );
+  }
+
+  void _addManualContact(AppState appState) {
+    final name = _manualNameController.text.trim();
+    final phone = _manualPhoneController.text.trim();
+    appState.addManualContact(name, phone);
+    if (appState.lastErrorMessage == null) {
+      _manualNameController.clear();
+      _manualPhoneController.clear();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(builder: (context, appState, child) {
+      final query = _searchController.text.trim().toLowerCase();
+      final filteredContacts = query.isEmpty
+          ? appState.availableContacts
+          : appState.availableContacts
+              .where((contact) =>
+                  contact.displayName.toLowerCase().contains(query) ||
+                  contact.phoneDisplay.toLowerCase().contains(query))
+              .toList();
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text('Invite household members', style: AppText.headline()),
+          const SizedBox(height: AppSpacing.sm),
+          Text('Select contacts or add manually.', style: AppText.caption()),
+          const SizedBox(height: AppSpacing.md),
+          CupertinoTextField(
+            controller: _searchController,
+            placeholder: 'Search contacts',
+            onChanged: (_) => setState(() {}),
+            decoration: BoxDecoration(
+              color: CupertinoColors.white,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: AppColors.deepGreen, width: 2),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Row(
+            children: [
+              Expanded(
+                flex: 2,
+                child: CupertinoTextField(
+                  controller: _manualNameController,
+                  placeholder: 'Name',
+                  decoration: BoxDecoration(
+                    color: CupertinoColors.white,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: AppColors.deepGreen, width: 2),
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                flex: 3,
+                child: CupertinoTextField(
+                  controller: _manualPhoneController,
+                  placeholder: 'Phone number',
+                  keyboardType: TextInputType.phone,
+                  decoration: BoxDecoration(
+                    color: CupertinoColors.white,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: AppColors.deepGreen, width: 2),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Row(
+            children: [
+              CupertinoButton(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                onPressed: () => _showCountryPicker(context, appState),
+                child: Text(
+                  appState.selectedCountry == null
+                      ? 'Pick country'
+                      : '${appState.selectedCountry!.flagEmoji} +${appState.selectedCountry!.phoneCode}',
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              CupertinoButton.filled(
+                onPressed:
+                    appState.isBusy ? null : () => _addManualContact(appState),
+                child: const Text('Add'),
+              ),
+            ],
+          ),
+          if (appState.lastErrorMessage != null) ...[
+            const SizedBox(height: AppSpacing.sm),
+            Text(appState.lastErrorMessage!, style: AppText.caption()),
+          ],
+          const SizedBox(height: AppSpacing.md),
+          Expanded(
+            child: appState.contactsLoading
+                ? const Center(child: CupertinoActivityIndicator())
+                : CupertinoScrollbar(
+                    child: ListView.separated(
+                      itemCount: filteredContacts.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 6),
+                      itemBuilder: (context, index) {
+                        final contact = filteredContacts[index];
+                        final selected = appState.selectedContacts
+                            .any((item) => item.id == contact.id);
+                        return CupertinoButton(
+                          padding: EdgeInsets.zero,
+                          onPressed: () =>
+                              appState.toggleContactSelection(contact),
+                          child: Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: selected
+                                  ? AppColors.primaryGreen.withOpacity(0.12)
+                                  : CupertinoColors.white,
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                  color: AppColors.deepGreen, width: 1),
+                            ),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(contact.displayName,
+                                          style: AppText.body()),
+                                      const SizedBox(height: 4),
+                                      Text(contact.phoneDisplay,
+                                          style: AppText.caption()),
+                                    ],
+                                  ),
+                                ),
+                                if (selected)
+                                  const Icon(CupertinoIcons.check_mark_circled),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          CupertinoButton.filled(
+            onPressed: appState.isBusy || appState.selectedContacts.isEmpty
+                ? null
+                : () => appState.createHouseholdAndInvites(),
+            child: const Text('Complete'),
+          ),
+        ],
+      );
+    });
+  }
+}
+
+Widget onboardingContactsScreen() => const OnboardingContactsScreen();

--- a/lib/onboarding_invite_screen.dart
+++ b/lib/onboarding_invite_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+
+class OnboardingInviteScreen extends StatelessWidget {
+  const OnboardingInviteScreen({super.key});
+
+  Future<void> _showDeclineDialog(
+      BuildContext context, AppState appState) async {
+    final controller = TextEditingController();
+    final result = await showCupertinoDialog<bool>(
+      context: context,
+      builder: (context) {
+        return CupertinoAlertDialog(
+          title: const Text('Decline invite?'),
+          content: Column(
+            children: [
+              const SizedBox(height: AppSpacing.sm),
+              const Text('Optional message to the inviter:'),
+              const SizedBox(height: AppSpacing.sm),
+              CupertinoTextField(
+                controller: controller,
+                placeholder: 'Add a message (optional)',
+              ),
+            ],
+          ),
+          actions: [
+            CupertinoDialogAction(
+              child: const Text('Cancel'),
+              onPressed: () => Navigator.of(context).pop(false),
+            ),
+            CupertinoDialogAction(
+              isDestructiveAction: true,
+              child: const Text('Decline'),
+              onPressed: () => Navigator.of(context).pop(true),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (result == true) {
+      final message = controller.text.trim();
+      await appState.declineInvite(message.isEmpty ? null : message);
+    }
+  }
+
+  String _buildInviterText(List<String> names) {
+    if (names.isEmpty) return 'Someone';
+    if (names.length == 1) return names.first;
+    if (names.length == 2) return '${names[0]} and ${names[1]}';
+    return '${names.sublist(0, names.length - 1).join(', ')} and ${names.last}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(builder: (context, appState, child) {
+      final inviterText = _buildInviterText(appState.pendingInviteInviterNames);
+      final householdName = appState.pendingInviteHouseholdName ?? 'their';
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text('You\'ve been invited', style: AppText.headline()),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            '$inviterText invited you to join $householdName household. Join?',
+            style: AppText.body(),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          CupertinoButton.filled(
+            onPressed: appState.isBusy ? null : () => appState.acceptInvite(),
+            child: const Text('Join'),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          CupertinoButton(
+            onPressed: appState.isBusy
+                ? null
+                : () => _showDeclineDialog(context, appState),
+            child: const Text('Decline'),
+          ),
+        ],
+      );
+    });
+  }
+}
+
+Widget onboardingInviteScreen() => const OnboardingInviteScreen();

--- a/lib/onboarding_invite_sent_screen.dart
+++ b/lib/onboarding_invite_sent_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+
+class OnboardingInviteSentScreen extends StatelessWidget {
+  const OnboardingInviteSentScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(builder: (context, appState, child) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text('Invites sent!', style: AppText.headline()),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'We\'ve sent them an invite. Hold tight, and we\'ll notify you once they\'ve joined.',
+            style: AppText.body(),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          CupertinoButton.filled(
+            onPressed: () => appState.navigateToPage('start'),
+            child: const Text('Continue'),
+          ),
+        ],
+      );
+    });
+  }
+}
+
+Widget onboardingInviteSentScreen() => const OnboardingInviteSentScreen();

--- a/lib/onboarding_profile_screen.dart
+++ b/lib/onboarding_profile_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+
+class OnboardingProfileScreen extends StatefulWidget {
+  const OnboardingProfileScreen({super.key});
+
+  @override
+  State<OnboardingProfileScreen> createState() =>
+      _OnboardingProfileScreenState();
+}
+
+class _OnboardingProfileScreenState extends State<OnboardingProfileScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  String? _errorText;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit(AppState appState) async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      setState(() => _errorText = 'Please enter your name.');
+      return;
+    }
+    setState(() => _errorText = null);
+    await appState.completeProfileName(name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (context, appState, child) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Tell us your name', style: AppText.headline()),
+            const SizedBox(height: AppSpacing.md),
+            CupertinoTextField(
+              controller: _nameController,
+              placeholder: 'Full name',
+              onSubmitted: (_) => _submit(appState),
+              decoration: BoxDecoration(
+                color: CupertinoColors.white,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: AppColors.deepGreen, width: 2),
+              ),
+            ),
+            if (_errorText != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(_errorText!, style: AppText.caption()),
+            ],
+            const SizedBox(height: AppSpacing.lg),
+            CupertinoButton.filled(
+              onPressed: () => _submit(appState),
+              child: const Text('Continue'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+Widget onboardingProfileScreen() => const OnboardingProfileScreen();

--- a/lib/phone_otp_page.dart
+++ b/lib/phone_otp_page.dart
@@ -56,6 +56,7 @@ class _PhoneOtpPageState extends State<PhoneOtpPage> {
     _otpCtrl.clear();
     setState(() => _codeSent = false);
     context.read<AppState>().setSignedIn(true);
+    await context.read<AppState>().handleSignedIn();
   }
 
   @override

--- a/lib/styles/app_styles.dart
+++ b/lib/styles/app_styles.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/cupertino.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppColors {
+  static const Color primaryGreen = Color(0xFF228B22);
+  static const Color deepGreen = Color(0xFF196719);
+  static const Color cream = Color(0xFFF9F5D2);
+  static const Color ink = Color(0xFF1B1B1B);
+  static const Color muted = Color(0xFF6B6B6B);
+}
+
+class AppText {
+  static TextStyle title() {
+    return GoogleFonts.modak(
+      fontSize: 36,
+      color: AppColors.primaryGreen,
+    );
+  }
+
+  static TextStyle headline() {
+    return const TextStyle(
+      fontSize: 24,
+      fontWeight: FontWeight.w700,
+      color: AppColors.ink,
+    );
+  }
+
+  static TextStyle body() {
+    return const TextStyle(
+      fontSize: 16,
+      color: AppColors.ink,
+    );
+  }
+
+  static TextStyle caption() {
+    return const TextStyle(
+      fontSize: 13,
+      color: AppColors.muted,
+    );
+  }
+}
+
+class AppSpacing {
+  static const double xs = 8;
+  static const double sm = 12;
+  static const double md = 16;
+  static const double lg = 24;
+  static const double xl = 32;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  country_picker:
+    dependency: "direct main"
+    description:
+      name: country_picker
+      sha256: "9b14c04f9a35e99f6de6bcbc453a556bb98345aecb481c7a0e843c94c2bee1f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.27"
   crypto:
     dependency: transitive
     description:
@@ -126,6 +134,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_contacts:
+    dependency: "direct main"
+    description:
+      name: flutter_contacts
+      sha256: "388d32cd33f16640ee169570128c933b45f3259bddbfae7a100bb49e5ffea9ae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9+2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -357,6 +373,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  onesignal_flutter:
+    dependency: "direct main"
+    description:
+      name: onesignal_flutter
+      sha256: f3b74f0ed20923bfcb8aa1b6bcdb6be49c4574b1fbae0fdcaba189f44597db37
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,9 @@ dependencies:
   google_fonts: ^6.3.2
   supabase_auth_ui: ^0.5.5
   flutter_localization: ^0.3.3
+  flutter_contacts: ^1.1.9
+  country_picker: ^2.0.26
+  onesignal_flutter: ^5.1.6
 
 dev_dependencies:
   flutter_test:

--- a/supabase/functions/send-household-invite/index.ts
+++ b/supabase/functions/send-household-invite/index.ts
@@ -1,0 +1,94 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
+
+Deno.serve(async (req) => {
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response("Missing Authorization header", { status: 401 });
+    }
+
+    const {
+      household_id,
+      inviter_user_ids,
+      invites,
+    } = await req.json();
+
+    if (!household_id || !Array.isArray(invites)) {
+      return new Response("Invalid payload", { status: 400 });
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const { data: household } = await supabase
+      .from("households")
+      .select("name")
+      .eq("id", household_id)
+      .maybeSingle();
+
+    const { data: inviters } = await supabase
+      .from("users")
+      .select("display_name")
+      .in("id", inviter_user_ids ?? []);
+
+    const inviterNames = (inviters ?? [])
+      .map((row) => row.display_name || "Someone")
+      .filter(Boolean);
+
+    const inviterText =
+      inviterNames.length === 0
+        ? "Someone"
+        : inviterNames.length === 1
+        ? inviterNames[0]
+        : inviterNames.length === 2
+        ? `${inviterNames[0]} and ${inviterNames[1]}`
+        : `${inviterNames.slice(0, -1).join(", ")} and ${
+            inviterNames[inviterNames.length - 1]
+          }`;
+
+    const householdName = household?.name ?? "their household";
+
+    const inviteRows = invites.map((invite: any) => ({
+      household_id,
+      invited_phone_e164: invite.phone_e164,
+      inviter_user_ids: inviter_user_ids ?? [],
+      status: "pending",
+    }));
+
+    await supabase.from("household_invites").upsert(inviteRows, {
+      onConflict: "household_id,invited_phone_e164",
+    });
+
+    const accountSid = Deno.env.get("TWILIO_ACCOUNT_SID")!;
+    const authToken = Deno.env.get("TWILIO_AUTH_TOKEN")!;
+    const fromNumber = Deno.env.get("TWILIO_FROM_NUMBER")!;
+    const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
+
+    let sentCount = 0;
+    for (const invite of invites) {
+      const body = new URLSearchParams({
+        From: fromNumber,
+        To: invite.phone_e164,
+        Body: `${inviterText} invited you to join ${householdName} on Tally. Download the app to join.`,
+      });
+
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: "Basic " + btoa(`${accountSid}:${authToken}`),
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body,
+      });
+
+      if (res.ok) {
+        sentCount += 1;
+      }
+    }
+
+    return Response.json({ sent: sentCount });
+  } catch (error) {
+    return new Response(String(error), { status: 500 });
+  }
+});

--- a/supabase/functions/send-invite-accepted-push/index.ts
+++ b/supabase/functions/send-invite-accepted-push/index.ts
@@ -1,0 +1,71 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
+
+Deno.serve(async (req) => {
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response("Missing Authorization header", { status: 401 });
+    }
+
+    const { household_id, inviter_user_ids, accepted_user_name } =
+      await req.json();
+
+    if (!household_id || !Array.isArray(inviter_user_ids)) {
+      return new Response("Invalid payload", { status: 400 });
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const { data: household } = await supabase
+      .from("households")
+      .select("name")
+      .eq("id", household_id)
+      .maybeSingle();
+
+    const { data: inviters } = await supabase
+      .from("users")
+      .select("onesignal_player_id")
+      .in("id", inviter_user_ids);
+
+    const playerIds = (inviters ?? [])
+      .map((row) => row.onesignal_player_id)
+      .filter((id) => typeof id === "string" && id.length > 0);
+
+    if (playerIds.length === 0) {
+      return Response.json({ sent: 0 });
+    }
+
+    const appId = Deno.env.get("ONESIGNAL_APP_ID")!;
+    const apiKey = Deno.env.get("ONESIGNAL_REST_API_KEY")!;
+    const householdName = household?.name ?? "your household";
+
+    const payload = {
+      app_id: appId,
+      include_player_ids: playerIds,
+      headings: { en: "Invite accepted" },
+      contents: {
+        en: `${accepted_user_name ?? "Someone"} accepted your invite to ${householdName}.`,
+      },
+    };
+
+    const response = await fetch("https://onesignal.com/api/v1/notifications", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return new Response(text, { status: 500 });
+    }
+
+    return Response.json({ sent: playerIds.length });
+  } catch (error) {
+    return new Response(String(error), { status: 500 });
+  }
+});


### PR DESCRIPTION
- Implemented full onboarding flow based on the SVG: profile name, invite acceptance/decline, add members, contact selection, and invite sent screens.
- Added centralized styles in [app_styles.dart](app://-/index.html#) and wired onboarding navigation into [main.dart](app://-/index.html#).
- Expanded AppState to handle onboarding orchestration, invite state, contact import/selection, and household creation.
- Added Supabase schema changes: household_invites table + invite_status enum; new user columns (auth_user_id, phone_e164, onesignal_player_id, country_code).
- Added Supabase Edge Functions: send-household-invite (Twilio SMS) and send-invite-accepted-push (OneSignal).
- Added iOS contacts permission in Info.plist.
- Added dev override flags to force onboarding screens for local testing.

## Notes

- OneSignal/APNs logic is intentionally commented out and gated behind AppConfig.enablePushNotifications = false so the app runs without Apple push setup.
- Edge functions are deployed but push invoke is disabled until APNs/OneSignal are configured.