### PR TITLE
Security review fixes: enable RLS, authorize edge functions, unblock local runner

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -155,7 +155,7 @@ SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_contacts: 5383945387e7ca37cf963d4be57c21f2fc15ca9f
+  flutter_contacts: 2ec1d6b62ca2869c3bbb3871bd74d4e3ef157135
   flutter_localization: 72299fb6cb4e51cae587bd953ed0b958040b71e6
   google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,31 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSContactsUsageDescription</key>
+	<string>We use your contacts to invite household members.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,11 +68,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>NSContactsUsageDescription</key>
-	<string>We use your contacts to invite household members.</string>
 </dict>
 </plist>

--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -483,22 +483,26 @@ class AppState extends ChangeNotifier {
     availableContacts = [];
     notifyListeners();
     try {
-      final permissionGranted = await FlutterContacts.requestPermission();
+      final status =
+          await FlutterContacts.permissions.request(PermissionType.read);
+      final permissionGranted = status == PermissionStatus.granted ||
+          status == PermissionStatus.limited;
       if (!permissionGranted) {
         lastErrorMessage = 'Contacts permission denied.';
         return;
       }
-      final contacts = await FlutterContacts.getContacts(
-        withProperties: true,
-        withThumbnail: false,
+      final contacts = await FlutterContacts.getAll(
+        properties: {ContactProperty.name, ContactProperty.phone},
       );
-      availableContacts =
-          contacts.where((contact) => contact.phones.isNotEmpty).map((contact) {
+      availableContacts = contacts
+          .where((contact) =>
+              contact.id != null && contact.phones.isNotEmpty)
+          .map((contact) {
         final phoneDisplay = contact.phones.first.number;
         final phoneE164 = normalizeToE164(phoneDisplay);
         return InviteContact(
-          id: contact.id,
-          displayName: contact.displayName,
+          id: contact.id!,
+          displayName: contact.displayName ?? 'Unknown',
           phoneE164: phoneE164,
           phoneDisplay: phoneDisplay,
         );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import app_links
+import flutter_contacts
 import flutter_localization
 import google_sign_in_ios
 import path_provider_foundation
@@ -15,6 +16,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
+  FlutterContactsPlugin.register(with: registry.registrar(forPlugin: "FlutterContactsPlugin"))
   FlutterLocalizationPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalizationPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "supabase:local": "supabase start && supabase functions serve --no-verify-jwt --env-file .env.local",
-    "run:local": "bash -c 'set -a && source .env.local && DEVICE_NAME=\"iPhone 16e\" && DEVICE_ID=$(xcrun simctl list devices available | awk -v name=\"$DEVICE_NAME\" -F \"[()]\" \"$1 ~ name {print $2; exit}\") && if [ -z \"$DEVICE_ID\" ]; then echo \"Simulator device not found: $DEVICE_NAME\"; exit 1; fi; xcrun simctl boot \"$DEVICE_ID\" >/dev/null 2>&1 || true; open -a Simulator; flutter run -d \"$DEVICE_ID\" --dart-define=SUPABASE_URL=$SUPABASE_URL --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY'",
+    "run:local": "bash -c 'set -a && source .env.local && DEVICE_ID=$(xcrun simctl list devices booted | grep -oE \"[(][0-9A-Fa-f-]{36}[)]\" | head -n1 | tr -d \"()\") && if [ -z \"$DEVICE_ID\" ]; then DEVICE_NAME=\"${DEVICE_NAME:-iPhone 17}\"; DEVICE_ID=$(xcrun simctl list devices available | grep -F \"$DEVICE_NAME\" | grep -oE \"[(][0-9A-Fa-f-]{36}[)]\" | head -n1 | tr -d \"()\"); fi && if [ -z \"$DEVICE_ID\" ]; then echo \"Simulator device not found: ${DEVICE_NAME:-iPhone 17}\"; exit 1; fi && xcrun simctl boot \"$DEVICE_ID\" >/dev/null 2>&1 ; open -a Simulator && flutter run -d \"$DEVICE_ID\" --dart-define=SUPABASE_URL=$SUPABASE_URL --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY'",
     "db:reset": "supabase db reset",
     "db:reset:household": "supabase db reset; psql postgresql://postgres:postgres@127.0.0.1:54322/postgres -f supabase/seeds/household.sql",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -130,10 +130,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_contacts
-      sha256: "388d32cd33f16640ee169570128c933b45f3259bddbfae7a100bb49e5ffea9ae"
+      sha256: be8e6de65fa7ae4332c812bcd4e8b90c0d74093fbda972ce3ca2f9f34f65e93c
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.9+2"
+    version: "2.0.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -329,18 +329,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -646,10 +646,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   google_fonts: ^6.3.2
   supabase_auth_ui: ^0.5.5
   flutter_localization: ^0.3.3
-  flutter_contacts: ^1.1.9
+  flutter_contacts: ^2.0.2
   onesignal_flutter: ^5.1.6
 
 dev_dependencies:

--- a/supabase/functions/send-household-invite/index.ts
+++ b/supabase/functions/send-household-invite/index.ts
@@ -1,10 +1,28 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 
+const safeSmsField = (value: string | null | undefined, max: number) =>
+  (value ?? "")
+    .replace(/[\x00-\x1F\x7F]/g, " ")
+    .slice(0, max);
+
 Deno.serve(async (req) => {
   try {
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) {
       return new Response("Missing Authorization header", { status: 401 });
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+    const userClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+      auth: { persistSession: false },
+    });
+    const { data: { user }, error: userErr } = await userClient.auth.getUser();
+    if (userErr || !user) {
+      return new Response("Invalid token", { status: 401 });
     }
 
     const {
@@ -17,9 +35,40 @@ Deno.serve(async (req) => {
       return new Response("Invalid payload", { status: 400 });
     }
 
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const { data: callerRow, error: callerErr } = await supabase
+      .from("users")
+      .select("id, household_id")
+      .eq("auth_user_id", user.id)
+      .maybeSingle();
+    if (callerErr || !callerRow) {
+      return new Response("Caller has no profile", { status: 403 });
+    }
+    if (callerRow.household_id !== household_id) {
+      return new Response("Caller is not a member of household", {
+        status: 403,
+      });
+    }
+
+    const inviterIds: number[] = Array.isArray(inviter_user_ids)
+      ? inviter_user_ids
+      : [];
+    if (!inviterIds.includes(callerRow.id)) {
+      return new Response("Caller missing from inviter_user_ids", {
+        status: 403,
+      });
+    }
+    const { data: inviterRows } = await supabase
+      .from("users")
+      .select("id, display_name")
+      .in("id", inviterIds)
+      .eq("household_id", callerRow.household_id);
+    if (!inviterRows || inviterRows.length !== inviterIds.length) {
+      return new Response("Inviter ids not all in caller household", {
+        status: 403,
+      });
+    }
 
     const { data: household } = await supabase
       .from("households")
@@ -27,12 +76,7 @@ Deno.serve(async (req) => {
       .eq("id", household_id)
       .maybeSingle();
 
-    const { data: inviters } = await supabase
-      .from("users")
-      .select("display_name")
-      .in("id", inviter_user_ids ?? []);
-
-    const inviterNames = (inviters ?? [])
+    const inviterNames = inviterRows
       .map((row) => row.display_name || "Someone")
       .filter(Boolean);
 
@@ -49,10 +93,14 @@ Deno.serve(async (req) => {
 
     const householdName = household?.name ?? "their household";
 
+    const smsInviterText = safeSmsField(inviterText, 80) || "Someone";
+    const smsHouseholdName = safeSmsField(householdName, 60) ||
+      "their household";
+
     const inviteRows = invites.map((invite: any) => ({
       household_id,
       invited_phone_e164: invite.phone_e164,
-      inviter_user_ids: inviter_user_ids ?? [],
+      inviter_user_ids: inviterIds,
       status: "pending",
     }));
 
@@ -70,7 +118,7 @@ Deno.serve(async (req) => {
       const body = new URLSearchParams({
         From: fromNumber,
         To: invite.phone_e164,
-        Body: `${inviterText} invited you to join ${householdName} on Tally. Download the app to join.`,
+        Body: `${smsInviterText} invited you to join ${smsHouseholdName} on Tally. Download the app to join.`,
       });
 
       const res = await fetch(url, {

--- a/supabase/functions/send-invite-accepted-push/index.ts
+++ b/supabase/functions/send-invite-accepted-push/index.ts
@@ -1,5 +1,10 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 
+const safeNotificationField = (value: string | null | undefined, max: number) =>
+  (value ?? "")
+    .replace(/[\x00-\x1F\x7F]/g, " ")
+    .slice(0, max);
+
 Deno.serve(async (req) => {
   try {
     const authHeader = req.headers.get("Authorization");
@@ -7,27 +12,44 @@ Deno.serve(async (req) => {
       return new Response("Missing Authorization header", { status: 401 });
     }
 
-    const { household_id, inviter_user_ids, accepted_user_name } =
-      await req.json();
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+    const userClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+      auth: { persistSession: false },
+    });
+    const { data: { user }, error: userErr } = await userClient.auth.getUser();
+    if (userErr || !user) {
+      return new Response("Invalid token", { status: 401 });
+    }
+
+    const { household_id, inviter_user_ids } = await req.json();
 
     if (!household_id || !Array.isArray(inviter_user_ids)) {
       return new Response("Invalid payload", { status: 400 });
     }
 
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, serviceRoleKey);
 
-    const { data: household } = await supabase
-      .from("households")
-      .select("name")
-      .eq("id", household_id)
+    const { data: callerRow, error: callerErr } = await supabase
+      .from("users")
+      .select("id, household_id, display_name")
+      .eq("auth_user_id", user.id)
       .maybeSingle();
+    if (callerErr || !callerRow) {
+      return new Response("Caller has no profile", { status: 403 });
+    }
+    if (callerRow.household_id !== household_id) {
+      return new Response("Caller is not in target household", { status: 403 });
+    }
 
     const { data: inviters } = await supabase
       .from("users")
       .select("onesignal_player_id")
-      .in("id", inviter_user_ids);
+      .in("id", inviter_user_ids)
+      .eq("household_id", callerRow.household_id);
 
     const playerIds = (inviters ?? [])
       .map((row) => row.onesignal_player_id)
@@ -37,16 +59,25 @@ Deno.serve(async (req) => {
       return Response.json({ sent: 0 });
     }
 
+    const { data: household } = await supabase
+      .from("households")
+      .select("name")
+      .eq("id", household_id)
+      .maybeSingle();
+
     const appId = Deno.env.get("ONESIGNAL_APP_ID")!;
     const apiKey = Deno.env.get("ONESIGNAL_REST_API_KEY")!;
-    const householdName = household?.name ?? "your household";
+    const householdName = safeNotificationField(household?.name, 60) ||
+      "your household";
+    const acceptedUserName =
+      safeNotificationField(callerRow.display_name, 80) || "Someone";
 
     const payload = {
       app_id: appId,
       include_player_ids: playerIds,
       headings: { en: "Invite accepted" },
       contents: {
-        en: `${accepted_user_name ?? "Someone"} accepted your invite to ${householdName}.`,
+        en: `${acceptedUserName} accepted your invite to ${householdName}.`,
       },
     };
 

--- a/supabase/migrations/20260428195853_enable_rls_and_policies.sql
+++ b/supabase/migrations/20260428195853_enable_rls_and_policies.sql
@@ -1,0 +1,222 @@
+-- Lock down anon access to public schema. Every legitimate flow runs after
+-- OTP verification, so the client always has an authenticated session by the
+-- time it reaches the database. Also revoke TRUNCATE from authenticated, since
+-- TRUNCATE bypasses RLS.
+
+revoke all on table
+    public.users,
+    public.households,
+    public.household_invites,
+    public.categories,
+    public.expenses,
+    public.user_expenses,
+    public.exceptions
+  from anon;
+
+revoke truncate on table
+    public.users,
+    public.households,
+    public.household_invites,
+    public.categories,
+    public.expenses,
+    public.user_expenses,
+    public.exceptions
+  from authenticated;
+
+
+-- A naive policy on public.users that joins back to public.users would recurse.
+-- Wrap the lookup in a SECURITY DEFINER helper so the inner read runs as the
+-- function owner and skips RLS.
+
+create or replace function public.current_user_household_id()
+returns integer
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select household_id from public.users where auth_user_id = auth.uid() limit 1
+$$;
+
+create or replace function public.current_user_phone_e164()
+returns text
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select phone from auth.users where id = auth.uid() limit 1
+$$;
+
+revoke all on function public.current_user_household_id() from public;
+grant execute on function public.current_user_household_id() to authenticated;
+
+revoke all on function public.current_user_phone_e164() from public;
+grant execute on function public.current_user_phone_e164() to authenticated;
+
+
+alter table public.users             enable row level security;
+alter table public.households        enable row level security;
+alter table public.household_invites enable row level security;
+alter table public.categories        enable row level security;
+alter table public.expenses          enable row level security;
+alter table public.user_expenses     enable row level security;
+alter table public.exceptions        enable row level security;
+
+
+-- public.users
+
+create policy "users_select_self" on public.users
+  for select to authenticated
+  using (auth_user_id = auth.uid());
+
+create policy "users_select_by_phone" on public.users
+  for select to authenticated
+  using (
+    phone_e164 is not null
+    and phone_e164 = public.current_user_phone_e164()
+  );
+
+create policy "users_select_household_members" on public.users
+  for select to authenticated
+  using (
+    household_id is not null
+    and household_id = public.current_user_household_id()
+  );
+
+-- An invitee who has not joined yet still needs to render inviter names from
+-- the pending invite they received.
+create policy "users_select_via_pending_invite" on public.users
+  for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.household_invites hi
+      where hi.status = 'pending'
+        and hi.invited_phone_e164 = public.current_user_phone_e164()
+        and public.users.id = any(hi.inviter_user_ids)
+    )
+  );
+
+create policy "users_insert_self" on public.users
+  for insert to authenticated
+  with check (auth_user_id = auth.uid());
+
+create policy "users_update_self" on public.users
+  for update to authenticated
+  using (auth_user_id = auth.uid())
+  with check (auth_user_id = auth.uid());
+
+-- Pre-seeded user rows (created before OTP, e.g. via an out-of-band import)
+-- get linked to their auth.users row on first sign-in.
+create policy "users_update_link_phone" on public.users
+  for update to authenticated
+  using (
+    auth_user_id is null
+    and phone_e164 is not null
+    and phone_e164 = public.current_user_phone_e164()
+  )
+  with check (
+    auth_user_id = auth.uid()
+    and phone_e164 = public.current_user_phone_e164()
+  );
+
+
+-- public.households
+
+create policy "households_select_member" on public.households
+  for select to authenticated
+  using (id = public.current_user_household_id());
+
+create policy "households_select_via_invite" on public.households
+  for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.household_invites hi
+      where hi.status = 'pending'
+        and hi.invited_phone_e164 = public.current_user_phone_e164()
+        and hi.household_id = public.households.id
+    )
+  );
+
+create policy "households_insert_authed" on public.households
+  for insert to authenticated
+  with check (auth.uid() is not null);
+
+
+-- public.household_invites
+
+create policy "invites_select_invitee" on public.household_invites
+  for select to authenticated
+  using (invited_phone_e164 = public.current_user_phone_e164());
+
+create policy "invites_select_household" on public.household_invites
+  for select to authenticated
+  using (household_id = public.current_user_household_id());
+
+create policy "invites_insert_member" on public.household_invites
+  for insert to authenticated
+  with check (
+    household_id = public.current_user_household_id()
+    and (
+      select id from public.users where auth_user_id = auth.uid() limit 1
+    ) = any(inviter_user_ids)
+  );
+
+create policy "invites_update_invitee" on public.household_invites
+  for update to authenticated
+  using (invited_phone_e164 = public.current_user_phone_e164())
+  with check (invited_phone_e164 = public.current_user_phone_e164());
+
+create policy "invites_update_member" on public.household_invites
+  for update to authenticated
+  using (household_id = public.current_user_household_id())
+  with check (household_id = public.current_user_household_id());
+
+
+-- public.categories, public.expenses, public.exceptions: scope to the
+-- caller's household.
+
+create policy "categories_household_rw" on public.categories
+  for all to authenticated
+  using (household_id = public.current_user_household_id())
+  with check (household_id = public.current_user_household_id());
+
+create policy "expenses_household_rw" on public.expenses
+  for all to authenticated
+  using (household_id = public.current_user_household_id())
+  with check (household_id = public.current_user_household_id());
+
+create policy "exceptions_household_rw" on public.exceptions
+  for all to authenticated
+  using (
+    household_id is not null
+    and household_id = public.current_user_household_id()
+  )
+  with check (
+    household_id is not null
+    and household_id = public.current_user_household_id()
+  );
+
+
+-- public.user_expenses has no household_id column; gate via the parent expense.
+
+create policy "user_expenses_household_rw" on public.user_expenses
+  for all to authenticated
+  using (
+    exists (
+      select 1
+      from public.expenses e
+      where e.id = public.user_expenses.expense_id
+        and e.household_id = public.current_user_household_id()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.expenses e
+      where e.id = public.user_expenses.expense_id
+        and e.household_id = public.current_user_household_id()
+    )
+  );


### PR DESCRIPTION
## Summary

Closes the three HIGH-severity findings from `/security-review` plus the two dev-experience blockers that surfaced during verification.

### Security fixes

- **Enable RLS and add household-scoped policies on every public table** (`e4fc7d6`). All seven public tables had `GRANT ALL ... TO anon, authenticated` and zero RLS, so anyone holding the public anon key could read or modify the entire database via `/rest/v1`. The new migration revokes anon DML, drops `TRUNCATE` from `authenticated`, adds two `SECURITY DEFINER` helpers (`current_user_household_id`, `current_user_phone_e164`) to avoid policy recursion on `public.users`, then enables RLS with policies that mirror every read/write the Flutter client performs in `lib/providers/app_state.dart` — including the pre-membership invite lookup and the inviter-display-name read during accept-invite.
- **Authorize `send-household-invite` caller** (`9c67228`). The function previously checked only that an `Authorization` header existed — never decoded the JWT, never verified household membership — and used a service-role client. Anyone could send Twilio SMS impersonating any user to any phone number, plant pending invites for any household, and pivot into household takeover via the existing `acceptInvite` flow. Now validates the bearer token via `auth.getUser()`, looks up the caller's `public.users` row, rejects with 403 if the caller isn't a member of `household_id`, and confirms every entry in `inviter_user_ids` belongs to that household. SMS body fields also get C0/DEL stripped + length-capped before interpolation.
- **Authorize `send-invite-accepted-push` caller** (`f39b6ae`). Same defect plus the `accepted_user_name` from the request body was interpolated straight into the OneSignal push, allowing arbitrary phishing-grade pushes to any user's device through the trusted Tally channel. Now validates the JWT, scopes `inviter_user_ids` to the caller's household before resolving `onesignal_player_id`, and derives the display name server-side from the authenticated caller's `users.display_name` instead of trusting the body.

### Dev-experience fixes (uncovered during verification)

- **`npm run run:local` device lookup** (`2757d24`). The awk script for the simulator lookup was double-quoted inside `bash -c`, so bash expanded `$1`/`$2` to empty before awk parsed them, leaving `~ name {print ; exit}` — syntax error. The non-zero exit short-circuited the `&& if [ -z DEVICE_ID ]` guard, so the script fell through to `flutter run -d ""` (the source of "Found N devices with name or id matching :"). Plus the hardcoded `iPhone 16e` was stale. Replaces the awk piece with `grep -oE`, prefers the booted simulator, falls back to `${DEVICE_NAME:-iPhone 17}`, and chains with `&&` so an empty `DEVICE_ID` actually halts.
- **Upgrade `flutter_contacts` 1.1.9 → 2.0.2** (`3a1da58`). 1.x crashed at plugin registration on the modern iOS scene lifecycle (`UIApplication.shared.delegate.window` is nil with `UIApplicationSceneManifest` + `FlutterSceneDelegate`, which the current Flutter SDK regenerates into `ios/Runner/Info.plist`). The plugin's 2.0.0-beta.4 release shipped the `UISceneDelegate` migration that fixes this. Reconciles the breaking API changes in `lib/providers/app_state.dart`: `requestPermission()` → `permissions.request(PermissionType.read)`, `getContacts(...)` → `getAll(properties: {...})`, and `Contact.id` / `Contact.displayName` becoming nullable.

## Test plan

- [x] `supabase db reset` applies the new RLS migration cleanly and seeds load.
- [x] RLS verified against the local DB: anon role gets `permission denied`; authed user A sees only their household's rows; stranger UUID sees 0 across users/households/expenses; cross-household `UPDATE`/`DELETE` reports 0 rows.
- [x] Pre-membership invite path verified: an invitee can read their pending invite, the invited household name, and the inviter row; cannot read non-inviter household members or expenses until they join.
- [x] `flutter build ios --simulator --no-codesign` succeeds after `flutter clean` (post-upgrade).
- [x] `npm run run:local` boots the iPhone 17 sim, builds, launches the app, Supabase init completes — confirmed visually on the welcome screen.
- [ ] Manual fuzz of both edge functions via `curl` with missing/invalid/cross-household JWTs (reviewer to run with `supabase functions serve --env-file .env.local`).
- [ ] Full happy-path walkthrough in simulator: brand-new phone → create-household path; brand-new phone → accept-invite path; brand-new phone → decline-invite path; returning user → housemates/expenses/exceptions load.
- [ ] Production deploy: re-run `supabase db push` and `supabase functions deploy send-household-invite send-invite-accepted-push`.