### PR TITLE
Fix local dev: skip login + skip onboarding for seeded mock user

### DIFF
--- a/lib/phone_otp_page.dart
+++ b/lib/phone_otp_page.dart
@@ -38,15 +38,17 @@ class _PhoneOtpPageState extends State<PhoneOtpPage> {
   }
 
   Future<void> _sendOtp() async {
+    final phone = context.read<AppState>().normalizeToE164(_phoneCtrl.text.trim());
     await supabase.auth.signInWithOtp(
-      phone: _phoneCtrl.text.trim(),
+      phone: phone,
     ); // sends SMS OTP
     setState(() => _codeSent = true);
   }
 
   Future<void> _verifyOtp() async {
+    final phone = context.read<AppState>().normalizeToE164(_phoneCtrl.text.trim());
     final res = await supabase.auth.verifyOTP(
-      phone: _phoneCtrl.text.trim(),
+      phone: phone,
       token: _otpCtrl.text.trim(),
       type: OtpType.sms,
     ); // creates session if code is valid

--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -97,11 +97,18 @@ class AppState extends ChangeNotifier {
   //
 
   void initializeView() {
-    // delay for testing
-    Future.delayed(const Duration(seconds: 2), () => navigateToPage('signin'));
-
-    // without delay:
-    // navigateToPage('signin');
+    // 2s delay so the logo screen has time to render before routing.
+    Future.delayed(const Duration(seconds: 2), () async {
+      // supabase_flutter persists sessions across launches; honor that
+      // instead of unconditionally sending the user back to signin.
+      final session = supabase.auth.currentSession;
+      if (session != null) {
+        setSignedIn(true);
+        await handleSignedIn();
+        return;
+      }
+      navigateToPage('signin');
+    });
   }
 
   //

--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -555,7 +555,7 @@ class AppState extends ChangeNotifier {
     if (trimmed.startsWith('+')) {
       return trimmed.replaceAll(RegExp(r'[^0-9+]'), '');
     }
-    final digits = trimmed.replaceAll(RegExp(r'\\D'), '');
+    final digits = trimmed.replaceAll(RegExp(r'\D'), '');
     if (digits.length == 10) {
       return '+1$digits';
     }

--- a/supabase/migrations/20260501132700_fix_phone_e164_helper_normalization.sql
+++ b/supabase/migrations/20260501132700_fix_phone_e164_helper_normalization.sql
@@ -1,0 +1,25 @@
+-- GoTrue stores auth.users.phone without the leading '+', even when the
+-- client sends an E.164-formatted number. The previous helper returned the
+-- raw value, so a comparison like
+--   public.users.phone_e164 = current_user_phone_e164()
+-- would compare e.g. '+16025459712' to '16025459712' and always be false.
+-- That breaks the post-OTP RLS lookup that lets a freshly-signed-in user
+-- discover their pre-seeded public.users row by phone.
+--
+-- Re-create the helper to always return E.164 (prepending '+' when missing)
+-- so callers can rely on the format implied by its name.
+
+create or replace function public.current_user_phone_e164()
+returns text
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select case
+    when phone is null or phone = '' then null
+    when phone like '+%' then phone
+    else '+' || phone
+  end
+  from auth.users where id = auth.uid() limit 1
+$$;

--- a/supabase/seeds/household.sql
+++ b/supabase/seeds/household.sql
@@ -7,8 +7,9 @@
 -- Drop any prior auth.users row for the test phone so re-seeding is deterministic.
 -- supabase db reset does not always wipe the auth schema; an orphaned auth row
 -- with a non-E.164 phone would prevent the new OTP login from matching the
--- seeded public.users.phone_e164.
-DELETE FROM auth.users WHERE phone IN ('+16025459712', '6025459712');
+-- seeded public.users.phone_e164. GoTrue stores phone as '16025459712' (no '+'
+-- prefix) regardless of how the client sends it, so cover both forms.
+DELETE FROM auth.users WHERE phone IN ('+16025459712', '16025459712', '6025459712');
 
 -- Household
 INSERT INTO public.households (id, name) VALUES (1, 'The Test House');

--- a/supabase/seeds/household.sql
+++ b/supabase/seeds/household.sql
@@ -4,6 +4,12 @@
 -- Usage: npm run db:reset:household
 -- ============================================================
 
+-- Drop any prior auth.users row for the test phone so re-seeding is deterministic.
+-- supabase db reset does not always wipe the auth schema; an orphaned auth row
+-- with a non-E.164 phone would prevent the new OTP login from matching the
+-- seeded public.users.phone_e164.
+DELETE FROM auth.users WHERE phone IN ('+16025459712', '6025459712');
+
 -- Household
 INSERT INTO public.households (id, name) VALUES (1, 'The Test House');
 SELECT setval('public.households_id_seq', 1);


### PR DESCRIPTION
## Summary

Restores the documented local dev flow so a developer with a seeded household lands directly in the main app — both on cold start (after first OTP) and on every relaunch.

Two independent bugs (plus one latent regex bug) were preventing this:

- **No session restore on launch** — `initializeView()` always routed to `'signin'` after the logo delay, ignoring the persisted Supabase session.
- **Phone format mismatch broke the RLS bootstrap** — the OTP UI sent raw `6025459712` to GoTrue, which stored it without the `+1`, so the `users_select_by_phone` policy could never match the seeded `phone_e164 = '+16025459712'`. The freshly-signed-in user was invisible to themselves and got routed into onboarding instead of the main app.
- **`normalizeToE164` regex bug** — `r'\\D'` matched a literal backslash-D instead of any non-digit, so formatted inputs like `(602) 545-9712` were never stripped.

## Changes

| Commit | What |
|---|---|
| f2379db | Seed prepends `DELETE FROM auth.users` for the test phone so re-seeding is deterministic |
| b61ffe1 | Normalize phone to E.164 in `phone_otp_page` before `signInWithOtp` / `verifyOTP`; defense-in-depth `+` prefix in the SQL helper |
| b15f370 | Fix `normalizeToE164` regex (`r'\\D'` → `r'\D'`) |
| 0c64c23 | `initializeView()` checks `supabase.auth.currentSession` and runs `handleSignedIn()` if present, falling back to `'signin'` otherwise |

## Test plan

End-to-end verified from a clean state (`supabase stop` → `supabase:local` → `db:reset:household` → `run:local`):

- [x] **Cold launch (no session)** — logo → signin. Enter `6025459712` / `123456` → lands directly on `'start'` (income input with `Enter Joel's net income`), skipping all onboarding screens. DB confirms `auth_user_id` linked on `public.users` row 1, single `auth.users` row created.
- [x] **Relaunch (`simctl terminate` + `simctl launch`)** — goes straight to `'start'`. No signin, no logo screen detour. Session restore via `currentSession` check works.