### PR TITLE
Tally Home design: home screen, redesigned menu, floating nav buttons

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/lib/app_settings_screen.dart
+++ b/lib/app_settings_screen.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
+
+Widget appSettingsScreen() {
+  return Consumer<AppState>(
+    builder: (context, appState, _) {
+      return SafeArea(
+        child: Stack(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg - 4, // 20
+                AppSpacing.lg,
+                AppSpacing.lg - 4, // 20
+                120, // clearance for floating back button
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('APPEARANCE', style: AppText.sectionLabel()),
+                  const SizedBox(height: AppSpacing.sm),
+                  _SettingsCard(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.md,
+                        vertical: 14,
+                      ),
+                      child: Row(
+                        children: [
+                          const Icon(
+                            CupertinoIcons.sun_max,
+                            color: CupertinoColors.systemYellow,
+                          ),
+                          const SizedBox(width: AppSpacing.sm),
+                          Expanded(
+                            child: Text(
+                              'Dark mode',
+                              style: AppText.cardItemTitle(),
+                            ),
+                          ),
+                          CupertinoSwitch(
+                            value: appState.brightnessModeSwitchValue,
+                            activeTrackColor: AppColors.deepGreen,
+                            onChanged: (_) => appState.toggleBrightnessMode(),
+                          ),
+                          const SizedBox(width: AppSpacing.sm),
+                          const Icon(
+                            CupertinoIcons.moon,
+                            color: AppColors.muted,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Positioned(
+              left: AppSpacing.lg - 4, // 20
+              bottom: 28,
+              child: FloatingNavButton.back(
+                onPressed: () => appState.navigateToPage('menu'),
+              ),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+class _SettingsCard extends StatelessWidget {
+  final Widget child;
+
+  const _SettingsCard({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surfaceWhite,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.hairline),
+        boxShadow: AppShadows.card,
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/app_settings_screen.dart
+++ b/lib/app_settings_screen.dart
@@ -8,66 +8,74 @@ import 'widgets/floating_nav_button.dart';
 Widget appSettingsScreen() {
   return Consumer<AppState>(
     builder: (context, appState, _) {
-      return SafeArea(
-        child: Stack(
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(
-                AppSpacing.lg - 4, // 20
-                AppSpacing.lg,
-                AppSpacing.lg - 4, // 20
-                120, // clearance for floating back button
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('APPEARANCE', style: AppText.sectionLabel()),
-                  const SizedBox(height: AppSpacing.sm),
-                  _SettingsCard(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.md,
-                        vertical: 14,
-                      ),
-                      child: Row(
-                        children: [
-                          const Icon(
-                            CupertinoIcons.sun_max,
-                            color: CupertinoColors.systemYellow,
-                          ),
-                          const SizedBox(width: AppSpacing.sm),
-                          Expanded(
-                            child: Text(
-                              'Dark mode',
-                              style: AppText.cardItemTitle(),
+      return Stack(
+        children: [
+          SafeArea(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(
+                      AppSpacing.lg - 4, // 20
+                      AppSpacing.lg,
+                      AppSpacing.lg - 4, // 20
+                      120, // clearance for floating back button
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('APPEARANCE', style: AppText.sectionLabel()),
+                        const SizedBox(height: AppSpacing.sm),
+                        _SettingsCard(
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: AppSpacing.md,
+                              vertical: 14,
+                            ),
+                            child: Row(
+                              children: [
+                                const Icon(
+                                  CupertinoIcons.sun_max,
+                                  color: CupertinoColors.systemYellow,
+                                ),
+                                const SizedBox(width: AppSpacing.sm),
+                                Expanded(
+                                  child: Text(
+                                    'Dark mode',
+                                    style: AppText.cardItemTitle(),
+                                  ),
+                                ),
+                                CupertinoSwitch(
+                                  value: appState.brightnessModeSwitchValue,
+                                  activeTrackColor: AppColors.deepGreen,
+                                  onChanged: (_) =>
+                                      appState.toggleBrightnessMode(),
+                                ),
+                                const SizedBox(width: AppSpacing.sm),
+                                const Icon(
+                                  CupertinoIcons.moon,
+                                  color: AppColors.muted,
+                                ),
+                              ],
                             ),
                           ),
-                          CupertinoSwitch(
-                            value: appState.brightnessModeSwitchValue,
-                            activeTrackColor: AppColors.deepGreen,
-                            onChanged: (_) => appState.toggleBrightnessMode(),
-                          ),
-                          const SizedBox(width: AppSpacing.sm),
-                          const Icon(
-                            CupertinoIcons.moon,
-                            color: AppColors.muted,
-                          ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-            Positioned(
-              left: AppSpacing.lg - 4, // 20
-              bottom: 28,
-              child: FloatingNavButton.back(
-                onPressed: () => appState.navigateToPage('menu'),
-              ),
+          ),
+          Positioned(
+            left: AppSpacing.lg - 4, // 20
+            bottom: AppSpacing.lg - 4, // 20
+            child: FloatingNavButton.back(
+              onPressed: () => appState.navigateToPage('menu'),
             ),
-          ],
-        ),
+          ),
+        ],
       );
     },
   );

--- a/lib/config_screen.dart
+++ b/lib/config_screen.dart
@@ -8,106 +8,113 @@ import 'widgets/floating_nav_button.dart';
 Widget configScreen() {
   return Consumer<AppState>(builder: (context, appState, child) {
     final fieldText = TextEditingController();
-    return SafeArea(
-      child: Stack(
-        children: [
-          SingleChildScrollView(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.lg - 4, // 20
-              AppSpacing.lg,
-              AppSpacing.lg - 4, // 20
-              120, // clearance for floating back button
-            ),
-            child: Column(
-              children: <Widget>[
-                const Text('Customize Housemates'),
-                for (var housemate in appState.housemates)
-                  Row(
+    return Stack(
+      children: [
+        SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.lg - 4, // 20
+                    AppSpacing.lg,
+                    AppSpacing.lg - 4, // 20
+                    120, // clearance for floating back button
+                  ),
+                  child: Column(
                     children: <Widget>[
-                      Text(housemate['name']),
-                      CupertinoButton(
-                        padding: EdgeInsets.zero,
-                        child: const Icon(CupertinoIcons.delete),
-                        onPressed: () {
-                          appState.housemates.remove(housemate);
-                        },
+                      const Text('Customize Housemates'),
+                      for (var housemate in appState.housemates)
+                        Row(
+                          children: <Widget>[
+                            Text(housemate['name']),
+                            CupertinoButton(
+                              padding: EdgeInsets.zero,
+                              child: const Icon(CupertinoIcons.delete),
+                              onPressed: () {
+                                appState.housemates.remove(housemate);
+                              },
+                            ),
+                          ],
+                        ),
+                      Row(
+                        children: <Widget>[
+                          Expanded(
+                            child: CupertinoTextField(
+                              controller: fieldText,
+                              keyboardType: TextInputType.text,
+                              placeholder: 'Enter a new housemate\'s name',
+                            ),
+                          ),
+                          CupertinoButton(
+                            padding: EdgeInsets.zero,
+                            child: const Icon(CupertinoIcons.plus),
+                            onPressed: () {
+                              appState.housemates.add({
+                                'name': fieldText.text,
+                                'netIncome': 0,
+                                'percentageOfHouseholdIncome': 0,
+                              });
+                              fieldText.clear();
+                            },
+                          ),
+                        ],
+                      ),
+                      const Padding(
+                        padding: EdgeInsets.only(top: 60.0),
+                        child: Text('Customize Expenses'),
+                      ),
+                      for (var expense in appState.expenses)
+                        Row(
+                          children: <Widget>[
+                            Text(expense['name']),
+                            CupertinoButton(
+                              padding: EdgeInsets.zero,
+                              child: const Icon(CupertinoIcons.delete),
+                              onPressed: () {
+                                appState.expenses.remove(expense);
+                              },
+                            ),
+                          ],
+                        ),
+                      Row(
+                        children: <Widget>[
+                          Expanded(
+                            child: CupertinoTextField(
+                              controller: fieldText,
+                              keyboardType: TextInputType.text,
+                              placeholder: 'Enter a new expense\'s name',
+                            ),
+                          ),
+                          CupertinoButton(
+                            padding: EdgeInsets.zero,
+                            child: const Icon(CupertinoIcons.plus),
+                            onPressed: () {
+                              appState.expenses.add({
+                                'name': fieldText.text,
+                                'amount': 0,
+                              });
+                              fieldText.clear();
+                            },
+                          ),
+                        ],
                       ),
                     ],
                   ),
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: CupertinoTextField(
-                        controller: fieldText,
-                        keyboardType: TextInputType.text,
-                        placeholder: 'Enter a new housemate\'s name',
-                      ),
-                    ),
-                    CupertinoButton(
-                      padding: EdgeInsets.zero,
-                      child: const Icon(CupertinoIcons.plus),
-                      onPressed: () {
-                        appState.housemates.add({
-                          'name': fieldText.text,
-                          'netIncome': 0,
-                          'percentageOfHouseholdIncome': 0,
-                        });
-                        fieldText.clear();
-                      },
-                    ),
-                  ],
                 ),
-                const Padding(
-                  padding: EdgeInsets.only(top: 60.0),
-                  child: Text('Customize Expenses'),
-                ),
-                for (var expense in appState.expenses)
-                  Row(
-                    children: <Widget>[
-                      Text(expense['name']),
-                      CupertinoButton(
-                        padding: EdgeInsets.zero,
-                        child: const Icon(CupertinoIcons.delete),
-                        onPressed: () {
-                          appState.expenses.remove(expense);
-                        },
-                      ),
-                    ],
-                  ),
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: CupertinoTextField(
-                        controller: fieldText,
-                        keyboardType: TextInputType.text,
-                        placeholder: 'Enter a new expense\'s name',
-                      ),
-                    ),
-                    CupertinoButton(
-                      padding: EdgeInsets.zero,
-                      child: const Icon(CupertinoIcons.plus),
-                      onPressed: () {
-                        appState.expenses.add({
-                          'name': fieldText.text,
-                          'amount': 0,
-                        });
-                        fieldText.clear();
-                      },
-                    ),
-                  ],
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
-          Positioned(
-            left: AppSpacing.lg - 4, // 20
-            bottom: 28,
-            child: FloatingNavButton.back(
-              onPressed: () => appState.navigateToPage('menu'),
-            ),
+        ),
+        Positioned(
+          left: AppSpacing.lg - 4, // 20
+          bottom: AppSpacing.lg - 4, // 20
+          child: FloatingNavButton.back(
+            onPressed: () => appState.navigateToPage('menu'),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   });
 }

--- a/lib/config_screen.dart
+++ b/lib/config_screen.dart
@@ -1,90 +1,113 @@
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
+
 import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
 
 Widget configScreen() {
   return Consumer<AppState>(builder: (context, appState, child) {
     final fieldText = TextEditingController();
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        const Text('Customize Housemates'),
-        for (var housemate in appState.housemates)
-          Row(
-            children: <Widget>[
-              Text(housemate['name']),
-              CupertinoButton(
-                padding: EdgeInsets.zero,
-                child: const Icon(CupertinoIcons.delete),
-                onPressed: () {
-                  appState.housemates.remove(housemate);
-                },
-              ),
-            ],
+    return SafeArea(
+      child: Stack(
+        children: [
+          SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.lg - 4, // 20
+              AppSpacing.lg,
+              AppSpacing.lg - 4, // 20
+              120, // clearance for floating back button
+            ),
+            child: Column(
+              children: <Widget>[
+                const Text('Customize Housemates'),
+                for (var housemate in appState.housemates)
+                  Row(
+                    children: <Widget>[
+                      Text(housemate['name']),
+                      CupertinoButton(
+                        padding: EdgeInsets.zero,
+                        child: const Icon(CupertinoIcons.delete),
+                        onPressed: () {
+                          appState.housemates.remove(housemate);
+                        },
+                      ),
+                    ],
+                  ),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: CupertinoTextField(
+                        controller: fieldText,
+                        keyboardType: TextInputType.text,
+                        placeholder: 'Enter a new housemate\'s name',
+                      ),
+                    ),
+                    CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      child: const Icon(CupertinoIcons.plus),
+                      onPressed: () {
+                        appState.housemates.add({
+                          'name': fieldText.text,
+                          'netIncome': 0,
+                          'percentageOfHouseholdIncome': 0,
+                        });
+                        fieldText.clear();
+                      },
+                    ),
+                  ],
+                ),
+                const Padding(
+                  padding: EdgeInsets.only(top: 60.0),
+                  child: Text('Customize Expenses'),
+                ),
+                for (var expense in appState.expenses)
+                  Row(
+                    children: <Widget>[
+                      Text(expense['name']),
+                      CupertinoButton(
+                        padding: EdgeInsets.zero,
+                        child: const Icon(CupertinoIcons.delete),
+                        onPressed: () {
+                          appState.expenses.remove(expense);
+                        },
+                      ),
+                    ],
+                  ),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: CupertinoTextField(
+                        controller: fieldText,
+                        keyboardType: TextInputType.text,
+                        placeholder: 'Enter a new expense\'s name',
+                      ),
+                    ),
+                    CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      child: const Icon(CupertinoIcons.plus),
+                      onPressed: () {
+                        appState.expenses.add({
+                          'name': fieldText.text,
+                          'amount': 0,
+                        });
+                        fieldText.clear();
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
-        Row(
-          children: <Widget>[
-            Expanded(
-              child: CupertinoTextField(
-                controller: fieldText,
-                keyboardType: TextInputType.text,
-                placeholder: 'Enter a new housemate\'s name',
-              ),
+          Positioned(
+            left: AppSpacing.lg - 4, // 20
+            bottom: 28,
+            child: FloatingNavButton.back(
+              onPressed: () => appState.navigateToPage('menu'),
             ),
-            CupertinoButton(
-              padding: EdgeInsets.zero,
-              child: const Icon(CupertinoIcons.plus),
-              onPressed: () {
-                appState.housemates.add({
-                  'name': fieldText.text,
-                  'netIncome': 0,
-                  'percentageOfHouseholdIncome': 0,
-                });
-                fieldText.clear();
-              },
-            ),
-          ],
-        ),
-        const Padding(
-          padding: EdgeInsets.only(top: 60.0),
-          child: Text('Customize Expenses'),
-        ),
-        for (var expense in appState.expenses)
-          Row(
-            children: <Widget>[
-              Text(expense['name']),
-              CupertinoButton(
-                padding: EdgeInsets.zero,
-                child: const Icon(CupertinoIcons.delete),
-                onPressed: () {
-                  appState.expenses.remove(expense);
-                },
-              ),
-            ],
           ),
-        Row(
-          children: <Widget>[
-            Expanded(
-              child: CupertinoTextField(
-                controller: fieldText,
-                keyboardType: TextInputType.text,
-                placeholder: 'Enter a new expense\'s name',
-              ),
-            ),
-            CupertinoButton(
-              padding: EdgeInsets.zero,
-              child: const Icon(CupertinoIcons.plus),
-              onPressed: () {
-                appState.expenses.add({
-                  'name': fieldText.text,
-                  'amount': 0,
-                });
-                fieldText.clear();
-              },
-            ),
-          ],
-        ),
-      ],
+        ],
+      ),
     );
   });
 }

--- a/lib/exceptions_screen.dart
+++ b/lib/exceptions_screen.dart
@@ -15,18 +15,22 @@ Widget exceptionsScreen() {
       exceptions = appState.exceptions;
     }
 
-    return SafeArea(
-      child: Stack(
-        children: [
-          SingleChildScrollView(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.lg - 4, // 20
-              AppSpacing.lg,
-              AppSpacing.lg - 4, // 20
-              120, // clearance for floating back button
-            ),
-            child: Column(
-              children: <Widget>[
+    return Stack(
+      children: [
+        SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.lg - 4, // 20
+                    AppSpacing.lg,
+                    AppSpacing.lg - 4, // 20
+                    120, // clearance for floating back button
+                  ),
+                  child: Column(
+                    children: <Widget>[
           Padding(
             padding: const EdgeInsets.only(top: 10.0, bottom: 30.0),
             child: Row(
@@ -287,18 +291,21 @@ Widget exceptionsScreen() {
               ),
             ),
           ),
-              ],
-            ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ),
-          Positioned(
-            left: AppSpacing.lg - 4, // 20
-            bottom: 28,
-            child: FloatingNavButton.back(
-              onPressed: () => appState.navigateToPage('menu'),
-            ),
+        ),
+        Positioned(
+          left: AppSpacing.lg - 4, // 20
+          bottom: AppSpacing.lg - 4, // 20
+          child: FloatingNavButton.back(
+            onPressed: () => appState.navigateToPage('menu'),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   });
 }

--- a/lib/exceptions_screen.dart
+++ b/lib/exceptions_screen.dart
@@ -3,6 +3,8 @@ import 'package:provider/provider.dart';
 import 'providers/app_state.dart';
 import 'exceptions_category_dropdown.dart';
 import 'exceptions_save_confirmation.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
 
 Widget exceptionsScreen() {
   return Consumer<AppState>(builder: (context, appState, child) {
@@ -13,9 +15,18 @@ Widget exceptionsScreen() {
       exceptions = appState.exceptions;
     }
 
-    return SizedBox.expand(
-      child: Column(
-        children: <Widget>[
+    return SafeArea(
+      child: Stack(
+        children: [
+          SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.lg - 4, // 20
+              AppSpacing.lg,
+              AppSpacing.lg - 4, // 20
+              120, // clearance for floating back button
+            ),
+            child: Column(
+              children: <Widget>[
           Padding(
             padding: const EdgeInsets.only(top: 10.0, bottom: 30.0),
             child: Row(
@@ -276,7 +287,16 @@ Widget exceptionsScreen() {
               ),
             ),
           ),
-          const Spacer(),
+              ],
+            ),
+          ),
+          Positioned(
+            left: AppSpacing.lg - 4, // 20
+            bottom: 28,
+            child: FloatingNavButton.back(
+              onPressed: () => appState.navigateToPage('menu'),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/expenses_screen.dart
+++ b/lib/expenses_screen.dart
@@ -1,40 +1,70 @@
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
+
 import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
 
 Widget expensesScreen() {
   return Consumer<AppState>(builder: (context, appState, child) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        const Text(
-          'Next, enter the total amount of each household expense for the month.',
+    return Stack(
+      children: [
+        SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.lg - 4, // 20
+                    AppSpacing.lg,
+                    AppSpacing.lg - 4, // 20
+                    120, // clearance for floating menu button
+                  ),
+                  child: Column(
+                    children: <Widget>[
+                      const Text(
+                        'Next, enter the total amount of each household expense for the month.',
+                      ),
+                      for (int i = 0; i < appState.expenses.length; i++)
+                        CupertinoTextField(
+                          controller: appState.expensesAmountControllers[i],
+                          keyboardType: TextInputType.number,
+                          placeholder:
+                              'Enter ${appState.expenses[i]['name']}\'s total amount for the month',
+                        ),
+                      Container(
+                        margin: const EdgeInsets.only(top: 20.0),
+                        width: double.infinity,
+                        height: 50.0,
+                        decoration: BoxDecoration(
+                          color: CupertinoColors.activeBlue,
+                          borderRadius: BorderRadius.circular(25.0),
+                        ),
+                        child: CupertinoButton(
+                          padding: EdgeInsets.zero,
+                          child: const Text(
+                            'Next',
+                            style: TextStyle(color: CupertinoColors.white),
+                          ),
+                          onPressed: () {
+                            appState.updateHousematesShare();
+                            appState.navigateToPage('summary');
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
-        for (int i = 0; i < appState.expenses.length; i++)
-          CupertinoTextField(
-            controller: appState.expensesAmountControllers[i],
-            keyboardType: TextInputType.number,
-            placeholder:
-                'Enter ${appState.expenses[i]['name']}\'s total amount for the month',
-          ),
-        Container(
-          margin: const EdgeInsets.only(top: 20.0),
-          width: double.infinity,
-          height: 50.0,
-          decoration: BoxDecoration(
-            color: CupertinoColors.activeBlue,
-            borderRadius: BorderRadius.circular(25.0),
-          ),
-          child: CupertinoButton(
-            padding: EdgeInsets.zero,
-            child: const Text(
-              'Next',
-              style: TextStyle(color: CupertinoColors.white),
-            ),
-            onPressed: () {
-              appState.updateHousematesShare();
-              appState.navigateToPage('summary');
-            },
+        Positioned(
+          left: AppSpacing.lg - 4, // 20
+          bottom: AppSpacing.lg - 4, // 20
+          child: FloatingNavButton.menu(
+            onPressed: appState.openMenu,
           ),
         ),
       ],

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,0 +1,849 @@
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
+
+// TODO: replace mock paid / paidBy / exception with real schema fields once
+// the database tracks who fronted each expense and per-month paid totals.
+
+Widget homeScreen() {
+  return Consumer<AppState>(
+    builder: (context, appState, _) {
+      final data = _buildHomeData(appState);
+      final shares = _computeShares(data);
+
+      return SafeArea(
+        child: Stack(
+          children: [
+            Column(
+              children: [
+                _AppBar(householdName: data.householdName),
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(
+                      AppSpacing.lg - 4, // 20
+                      AppSpacing.xs,
+                      AppSpacing.lg - 4, // 20
+                      120, // clearance for floating menu button
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        _MonthHeader(data: data),
+                        const SizedBox(height: 18),
+                        _BalancesCard(data: data, totals: shares.totals),
+                        const SizedBox(height: 18),
+                        _ExpensesMatrix(data: data, shares: shares),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            Positioned(
+              left: AppSpacing.lg - 4, // 20
+              bottom: 28,
+              child: FloatingNavButton.menu(
+                onPressed: appState.openMenu,
+              ),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Internal data shapes
+// ─────────────────────────────────────────────────────────────────────────
+
+class _HomeMember {
+  final String id;
+  final String name;
+  final double share; // 0..1, fraction of household income
+  final double paid; // dollars actually fronted this month (mock for now)
+
+  const _HomeMember({
+    required this.id,
+    required this.name,
+    required this.share,
+    required this.paid,
+  });
+}
+
+class _HomeExpense {
+  final String id;
+  final String name;
+  final double amount;
+  final String paidBy; // member id (mock for now)
+  final Map<String, double>? exception; // memberId -> override share
+
+  const _HomeExpense({
+    required this.id,
+    required this.name,
+    required this.amount,
+    required this.paidBy,
+    this.exception,
+  });
+}
+
+class _HomeData {
+  final String householdName;
+  final String monthLabel;
+  final String previousMonthLabel;
+  final List<_HomeMember> members;
+  final List<_HomeExpense> expenses;
+  final String? exceptionFootnote;
+
+  const _HomeData({
+    required this.householdName,
+    required this.monthLabel,
+    required this.previousMonthLabel,
+    required this.members,
+    required this.expenses,
+    this.exceptionFootnote,
+  });
+}
+
+class _Shares {
+  final Map<String, Map<String, double>> perExpense; // expenseId -> memberId -> $
+  final Map<String, double> totals; // memberId -> $ owed total
+
+  const _Shares({required this.perExpense, required this.totals});
+}
+
+// Port of computeShares() from home.jsx — proportional split with per-expense
+// exception override + redistribution of removed weight.
+_Shares _computeShares(_HomeData data) {
+  final memberIds = data.members.map((m) => m.id).toList();
+  final baseShare = <String, double>{
+    for (final m in data.members) m.id: m.share,
+  };
+  final perExpense = <String, Map<String, double>>{};
+  final totals = <String, double>{for (final id in memberIds) id: 0.0};
+
+  for (final exp in data.expenses) {
+    final shares = Map<String, double>.from(baseShare);
+    final exception = exp.exception;
+    if (exception != null) {
+      final exMembers = exception.keys.toList();
+      for (final id in exMembers) {
+        shares[id] = exception[id]!;
+      }
+      final removed = exMembers.fold<double>(
+        0,
+        (s, id) => s + (baseShare[id]! - exception[id]!),
+      );
+      final remaining =
+          memberIds.where((id) => !exMembers.contains(id)).toList();
+      final remainingTotal = remaining.fold<double>(
+        0,
+        (s, id) => s + baseShare[id]!,
+      );
+      if (remainingTotal > 0) {
+        for (final id in remaining) {
+          shares[id] =
+              baseShare[id]! + removed * (baseShare[id]! / remainingTotal);
+        }
+      }
+    }
+    final cell = <String, double>{};
+    for (final id in memberIds) {
+      final v = exp.amount * shares[id]!;
+      cell[id] = v;
+      totals[id] = totals[id]! + v;
+    }
+    perExpense[exp.id] = cell;
+  }
+  return _Shares(perExpense: perExpense, totals: totals);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Data projection — bind real AppState data where available; mock the rest.
+// ─────────────────────────────────────────────────────────────────────────
+
+_HomeData _buildHomeData(AppState appState) {
+  final now = DateTime.now();
+  final pastMonth = DateTime(now.year, now.month - 1, 1);
+  final priorMonth = DateTime(now.year, now.month - 2, 1);
+  final monthLabel = _formatMonthYear(pastMonth);
+  final previousMonthLabel = _formatMonth(priorMonth);
+
+  final hasHousemates = appState.housemates.isNotEmpty;
+  final hasExpenses = appState.expenses.isNotEmpty;
+
+  if (!hasHousemates || !hasExpenses) {
+    return _sampleHomeData(
+      monthLabel: monthLabel,
+      previousMonthLabel: previousMonthLabel,
+    );
+  }
+
+  final householdName = appState.householdName ?? 'My Household';
+
+  // Compute member shares from real income data when present, else uniform.
+  final totalIncome = appState.housemates.fold<double>(
+    0,
+    (s, h) => s + _toDouble(h['netIncome']),
+  );
+  final hasIncome = totalIncome > 0;
+
+  final members = <_HomeMember>[];
+  for (final h in appState.housemates) {
+    final id = h['id'].toString();
+    final name = (h['display_name'] ?? h['name'] ?? 'Unknown').toString();
+    final income = _toDouble(h['netIncome']);
+    final share = hasIncome
+        ? income / totalIncome
+        : 1.0 / appState.housemates.length;
+    members.add(_HomeMember(id: id, name: name, share: share, paid: 0));
+  }
+
+  // Mock paid amounts: distribute the total spend across members in a shape
+  // that gives the home view interesting balances to render. Real schema
+  // doesn't yet track who fronted what.
+  final totalSpend = appState.expenses.fold<double>(
+    0,
+    (s, e) => s + _toDouble(e['amount']),
+  );
+  if (totalSpend > 0 && members.isNotEmpty) {
+    const mockSplit = [0.55, 0.45, 0.0];
+    for (var i = 0; i < members.length; i++) {
+      final factor = mockSplit[i % mockSplit.length];
+      final m = members[i];
+      members[i] = _HomeMember(
+        id: m.id,
+        name: m.name,
+        share: m.share,
+        paid: totalSpend * factor,
+      );
+    }
+  }
+
+  // Mock paidBy: cycle through members.
+  final expenses = <_HomeExpense>[];
+  for (var i = 0; i < appState.expenses.length; i++) {
+    final e = appState.expenses[i];
+    final id = (e['id'] ?? 'expense-$i').toString();
+    final name = (e['name'] ?? 'Unknown').toString();
+    final amount = _toDouble(e['amount']);
+    final paidBy = members.isNotEmpty ? members[i % members.length].id : '';
+    expenses.add(_HomeExpense(
+      id: id,
+      name: name,
+      amount: amount,
+      paidBy: paidBy,
+    ));
+  }
+
+  return _HomeData(
+    householdName: householdName,
+    monthLabel: monthLabel,
+    previousMonthLabel: previousMonthLabel,
+    members: members,
+    expenses: expenses,
+    exceptionFootnote: null,
+  );
+}
+
+// Sample data drawn directly from the design's home.jsx — used when there's
+// no real household data yet (fresh/empty state and dev preview).
+_HomeData _sampleHomeData({
+  required String monthLabel,
+  required String previousMonthLabel,
+}) {
+  return _HomeData(
+    householdName: 'Birch Street',
+    monthLabel: monthLabel,
+    previousMonthLabel: previousMonthLabel,
+    members: const [
+      _HomeMember(id: 'sam', name: 'Sam', share: 0.32, paid: 1180.00),
+      _HomeMember(id: 'pat', name: 'Pat', share: 0.44, paid: 2010.40),
+      _HomeMember(id: 'jules', name: 'Jules', share: 0.24, paid: 0),
+    ],
+    expenses: const [
+      _HomeExpense(id: 'rent', name: 'Rent', amount: 2400, paidBy: 'pat'),
+      _HomeExpense(id: 'util', name: 'Utilities', amount: 184, paidBy: 'pat'),
+      _HomeExpense(id: 'inet', name: 'Internet', amount: 70, paidBy: 'sam'),
+      _HomeExpense(
+        id: 'stream',
+        name: 'Streaming',
+        amount: 38,
+        paidBy: 'sam',
+        exception: {'sam': 0.0},
+      ),
+      _HomeExpense(id: 'groc', name: 'Groceries', amount: 612, paidBy: 'sam'),
+      _HomeExpense(
+        id: 'cleaning',
+        name: 'Cleaning',
+        amount: 80,
+        paidBy: 'pat',
+      ),
+    ],
+    exceptionFootnote: 'Streaming has an exception — Sam pays 0%.',
+  );
+}
+
+double _toDouble(dynamic v) {
+  if (v is num) return v.toDouble();
+  if (v is String) return double.tryParse(v) ?? 0.0;
+  return 0.0;
+}
+
+const _monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+String _formatMonth(DateTime d) => _monthNames[d.month - 1];
+String _formatMonthYear(DateTime d) => '${_monthNames[d.month - 1]} ${d.year}';
+
+String _formatMoneyCompact(double n, {bool compact = false}) {
+  if (compact && n.abs() >= 1000) {
+    final v = (n / 1000).toStringAsFixed(1).replaceAll(RegExp(r'\.0$'), '');
+    return '\$${v}k';
+  }
+  return '\$${_groupedInt(n)}';
+}
+
+String _formatMoneyPrecise(double n) {
+  return '\$${_groupedDecimal(n)}';
+}
+
+String _groupedInt(double n) {
+  final rounded = n.round();
+  return _addThousandsSeparator(rounded.toString());
+}
+
+String _groupedDecimal(double n) {
+  final fixed = n.toStringAsFixed(2);
+  final parts = fixed.split('.');
+  return '${_addThousandsSeparator(parts[0])}.${parts[1]}';
+}
+
+String _addThousandsSeparator(String intPart) {
+  final isNegative = intPart.startsWith('-');
+  final digits = isNegative ? intPart.substring(1) : intPart;
+  final buffer = StringBuffer();
+  for (var i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return isNegative ? '-${buffer.toString()}' : buffer.toString();
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sub-widgets
+// ─────────────────────────────────────────────────────────────────────────
+
+class _AppBar extends StatelessWidget {
+  final String householdName;
+
+  const _AppBar({required this.householdName});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 44,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg - 4),
+        child: Row(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                'Tally',
+                style: AppText.title(size: 26).copyWith(
+                  height: 1,
+                  letterSpacing: 0.4,
+                ),
+              ),
+            ),
+            const Spacer(),
+            const Icon(
+              CupertinoIcons.house_fill,
+              size: 13,
+              color: AppColors.muted,
+            ),
+            const SizedBox(width: AppSpacing.xxs + 2),
+            Text(
+              householdName,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+                color: AppColors.muted,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MonthHeader extends StatelessWidget {
+  final _HomeData data;
+
+  const _MonthHeader({required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    final expenseTotal = data.expenses.fold<double>(0, (s, e) => s + e.amount);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(
+              child: Text(data.monthLabel, style: AppText.monthHeader()),
+            ),
+            // Previous-month chevron affordance — visual only for v1.
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    CupertinoIcons.chevron_left,
+                    size: 14,
+                    color: AppColors.muted,
+                  ),
+                  const SizedBox(width: AppSpacing.xxs),
+                  Text(
+                    data.previousMonthLabel,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                      color: AppColors.muted,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '${data.expenses.length} shared expenses · '
+          '${_formatMoneyPrecise(expenseTotal)} total',
+          style: const TextStyle(fontSize: 14, color: AppColors.muted),
+        ),
+      ],
+    );
+  }
+}
+
+class _BalancesCard extends StatelessWidget {
+  final _HomeData data;
+  final Map<String, double> totals;
+
+  const _BalancesCard({required this.data, required this.totals});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surfaceWhite,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.hairline),
+        boxShadow: AppShadows.card,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: 14,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Expanded(
+                child: Text(
+                  'WHERE EVERYONE STANDS',
+                  style: AppText.sectionLabel(),
+                ),
+              ),
+              Text(
+                'paid − owed',
+                style: AppText.cardItemSub().copyWith(fontSize: 12),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          for (var i = 0; i < data.members.length; i++) ...[
+            if (i > 0) const SizedBox(height: 10),
+            _BalanceRow(
+              member: data.members[i],
+              owed: totals[data.members[i].id] ?? 0,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _BalanceRow extends StatelessWidget {
+  final _HomeMember member;
+  final double owed;
+
+  const _BalanceRow({required this.member, required this.owed});
+
+  @override
+  Widget build(BuildContext context) {
+    final balance = member.paid - owed;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 24,
+          child: Center(child: _MemberDisc(name: member.name)),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(member.name, style: AppText.cardItemTitle()),
+              const SizedBox(height: 2),
+              Text(
+                'paid ${_formatMoneyCompact(member.paid)} · '
+                'owed ${_formatMoneyCompact(owed)}',
+                style: AppText.cardItemSub(),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 10),
+        _BalancePill(amount: balance),
+      ],
+    );
+  }
+}
+
+class _MemberDisc extends StatelessWidget {
+  final String name;
+
+  const _MemberDisc({required this.name});
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = name.isNotEmpty ? name[0].toUpperCase() : '?';
+    return Container(
+      width: 22,
+      height: 22,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        color: AppColors.green12,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        initial,
+        style: const TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.2,
+          color: AppColors.deepGreen,
+          height: 1,
+        ),
+      ),
+    );
+  }
+}
+
+class _BalancePill extends StatelessWidget {
+  final double amount;
+
+  const _BalancePill({required this.amount});
+
+  @override
+  Widget build(BuildContext context) {
+    final isZero = amount.abs() < 0.5;
+    final isPositive = amount > 0;
+    final color = isZero
+        ? AppColors.muted
+        : (isPositive ? AppColors.balancePositive : AppColors.balanceNegative);
+    final sign = isZero ? '' : (isPositive ? '+' : '−');
+    return Text(
+      '$sign${_formatMoneyCompact(amount.abs())}',
+      style: AppText.balancePill(color: color),
+    );
+  }
+}
+
+class _ExpensesMatrix extends StatelessWidget {
+  final _HomeData data;
+  final _Shares shares;
+
+  const _ExpensesMatrix({required this.data, required this.shares});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 2, bottom: AppSpacing.xs),
+          child: Text(
+            'BREAKDOWN BY EXPENSE',
+            style: AppText.sectionLabel(),
+          ),
+        ),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            decoration: BoxDecoration(
+              color: AppColors.surfaceWhite,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: AppColors.hairline),
+              boxShadow: AppShadows.card,
+            ),
+            child: Column(
+              children: [
+                _MatrixHeaderRow(members: data.members),
+                for (var i = 0; i < data.expenses.length; i++)
+                  _MatrixExpenseRow(
+                    expense: data.expenses[i],
+                    members: data.members,
+                    cell: shares.perExpense[data.expenses[i].id]!,
+                    paidBy: _resolvePayerName(data, data.expenses[i].paidBy),
+                    isLast: i == data.expenses.length - 1,
+                  ),
+                _MatrixTotalsRow(members: data.members, totals: shares.totals),
+              ],
+            ),
+          ),
+        ),
+        if (data.exceptionFootnote != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          _ExceptionFootnote(text: data.exceptionFootnote!),
+        ],
+      ],
+    );
+  }
+
+  String _resolvePayerName(_HomeData data, String paidById) {
+    for (final m in data.members) {
+      if (m.id == paidById) return m.name;
+    }
+    return '—';
+  }
+}
+
+class _MatrixHeaderRow extends StatelessWidget {
+  final List<_HomeMember> members;
+
+  const _MatrixHeaderRow({required this.members});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 10, 14, 8),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: AppColors.hairline)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(child: Text('EXPENSE', style: AppText.tableColumnLabel())),
+          for (final m in members) ...[
+            const SizedBox(width: AppSpacing.xxs),
+            SizedBox(
+              width: 54,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(m.name, style: AppText.tableColumnName()),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${(m.share * 100).round()}%',
+                    style: const TextStyle(
+                      fontSize: 10,
+                      color: AppColors.muted,
+                      fontFeatures: [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _MatrixExpenseRow extends StatelessWidget {
+  final _HomeExpense expense;
+  final List<_HomeMember> members;
+  final Map<String, double> cell;
+  final String paidBy;
+  final bool isLast;
+
+  const _MatrixExpenseRow({
+    required this.expense,
+    required this.members,
+    required this.cell,
+    required this.paidBy,
+    required this.isLast,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final hasException = expense.exception != null;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        border: isLast
+            ? null
+            : const Border(bottom: BorderSide(color: AppColors.hairlineSoft)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Flexible(
+                      child: Text(
+                        expense.name,
+                        style: AppText.cardItemTitle(),
+                      ),
+                    ),
+                    if (hasException) ...[
+                      const SizedBox(width: 6),
+                      const Icon(
+                        CupertinoIcons.star_fill,
+                        size: 12,
+                        color: AppColors.primaryGreen,
+                      ),
+                    ],
+                  ],
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '${_formatMoneyCompact(expense.amount)} · paid by $paidBy',
+                  style: AppText.cardItemSub().copyWith(
+                    fontSize: 11,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          for (final m in members) ...[
+            const SizedBox(width: AppSpacing.xxs),
+            SizedBox(
+              width: 54,
+              child: _AmountCell(value: cell[m.id] ?? 0),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _AmountCell extends StatelessWidget {
+  final double value;
+
+  const _AmountCell({required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final isZero = value < 0.5;
+    return Text(
+      isZero ? '—' : _formatMoneyCompact(value),
+      textAlign: TextAlign.right,
+      style: AppText.tableCell(
+        color: isZero ? AppColors.placeholderGray : AppColors.ink,
+      ),
+    );
+  }
+}
+
+class _MatrixTotalsRow extends StatelessWidget {
+  final List<_HomeMember> members;
+  final Map<String, double> totals;
+
+  const _MatrixTotalsRow({required this.members, required this.totals});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: const BoxDecoration(
+        color: AppColors.surfaceWarm,
+        border: Border(top: BorderSide(color: AppColors.hairline)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Text('Total owed', style: AppText.tableTotalLabel()),
+          ),
+          for (final m in members) ...[
+            const SizedBox(width: AppSpacing.xxs),
+            SizedBox(
+              width: 54,
+              child: Text(
+                _formatMoneyCompact(totals[m.id] ?? 0),
+                textAlign: TextAlign.right,
+                style: AppText.tableTotalValue(),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ExceptionFootnote extends StatelessWidget {
+  final String text;
+
+  const _ExceptionFootnote({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 2),
+            child: Icon(
+              CupertinoIcons.star_fill,
+              size: 10,
+              color: AppColors.primaryGreen,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xxs),
+          Expanded(
+            child: Text(text, style: AppText.microCaption()),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -14,10 +14,10 @@ Widget homeScreen() {
       final data = _buildHomeData(appState);
       final shares = _computeShares(data);
 
-      return SafeArea(
-        child: Stack(
-          children: [
-            Column(
+      return Stack(
+        children: [
+          SafeArea(
+            child: Column(
               children: [
                 _AppBar(householdName: data.householdName),
                 Expanded(
@@ -42,15 +42,15 @@ Widget homeScreen() {
                 ),
               ],
             ),
-            Positioned(
-              left: AppSpacing.lg - 4, // 20
-              bottom: 28,
-              child: FloatingNavButton.menu(
-                onPressed: appState.openMenu,
-              ),
+          ),
+          Positioned(
+            left: AppSpacing.lg - 4, // 20
+            bottom: AppSpacing.lg - 4, // 20
+            child: FloatingNavButton.menu(
+              onPressed: appState.openMenu,
             ),
-          ],
-        ),
+          ),
+        ],
       );
     },
   );

--- a/lib/household_income_summary_screen.dart
+++ b/lib/household_income_summary_screen.dart
@@ -1,37 +1,67 @@
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
+
 import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
 
 Widget householdIncomeSummaryScreen() {
   return Consumer<AppState>(builder: (context, appState, child) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Text(
-            'Total household income: \$${appState.totalHouseholdIncome.toStringAsFixed(2)}'),
-        for (var housemate in appState.housemates)
-          Padding(
-            padding: const EdgeInsets.only(top: 10.0),
-            child: Text(
-                '${housemate['name']}\'s percentage of household income is ${housemate['percentageOfHouseholdIncome'].toStringAsFixed(2)}%'),
+    return Stack(
+      children: [
+        SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.lg - 4, // 20
+                    AppSpacing.lg,
+                    AppSpacing.lg - 4, // 20
+                    120, // clearance for floating menu button
+                  ),
+                  child: Column(
+                    children: <Widget>[
+                      Text(
+                          'Total household income: \$${appState.totalHouseholdIncome.toStringAsFixed(2)}'),
+                      for (var housemate in appState.housemates)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 10.0),
+                          child: Text(
+                              '${housemate['name']}\'s percentage of household income is ${housemate['percentageOfHouseholdIncome'].toStringAsFixed(2)}%'),
+                        ),
+                      Container(
+                        margin: const EdgeInsets.only(top: 20.0),
+                        width: double.infinity,
+                        height: 50.0,
+                        decoration: BoxDecoration(
+                          color: CupertinoColors.activeBlue,
+                          borderRadius: BorderRadius.circular(25.0),
+                        ),
+                        child: CupertinoButton(
+                          padding: EdgeInsets.zero,
+                          child: const Text(
+                            'Next',
+                            style: TextStyle(color: CupertinoColors.white),
+                          ),
+                          onPressed: () {
+                            appState.navigateToPage('expenses');
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ),
-        Container(
-          margin: const EdgeInsets.only(top: 20.0),
-          width: double.infinity,
-          height: 50.0,
-          decoration: BoxDecoration(
-            color: CupertinoColors.activeBlue,
-            borderRadius: BorderRadius.circular(25.0),
-          ),
-          child: CupertinoButton(
-            padding: EdgeInsets.zero,
-            child: const Text(
-              'Next',
-              style: TextStyle(color: CupertinoColors.white),
-            ),
-            onPressed: () {
-              appState.navigateToPage('expenses');
-            },
+        ),
+        Positioned(
+          left: AppSpacing.lg - 4, // 20
+          bottom: AppSpacing.lg - 4, // 20
+          child: FloatingNavButton.menu(
+            onPressed: appState.openMenu,
           ),
         ),
       ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -200,7 +200,7 @@ class MyHomePage extends StatelessWidget {
     ];
     // Pages that own their own padding/safe-area + draw their own floating
     // nav button instead of relying on the top CupertinoNavigationBar.
-    const fullBleedPages = {'home'};
+    const fullBleedPages = {'home', 'menu'};
 
     return Consumer<AppState>(
       builder: (context, appState, child) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'signin_screen.dart';
 import 'menu_screen.dart';
 import 'config_screen.dart';
 import 'exceptions_screen.dart';
+import 'home_screen.dart';
 import 'start_screen.dart';
 import 'household_income_summary_screen.dart';
 import 'expenses_screen.dart';
@@ -143,6 +144,9 @@ class MyHomePage extends StatelessWidget {
       case 'signin':
         screen = signinScreen();
         break;
+      case 'home':
+        screen = homeScreen();
+        break;
       case 'start':
         screen = startScreen();
         break;
@@ -188,16 +192,36 @@ class MyHomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     const flowPages = [
       'signin',
+      'home',
       'start',
       'expenses',
       'summary',
       'household income summary',
     ];
+    // Pages that own their own padding/safe-area + draw their own floating
+    // nav button instead of relying on the top CupertinoNavigationBar.
+    const fullBleedPages = {'home'};
+
     return Consumer<AppState>(
       builder: (context, appState, child) {
+        final isFullBleed = fullBleedPages.contains(appState.currentPage);
+
+        final pageContent = AnimatedSwitcher(
+          duration: const Duration(milliseconds: 500),
+          transitionBuilder: (Widget child, Animation<double> animation) {
+            return FadeTransition(opacity: animation, child: child);
+          },
+          child: SizedBox.expand(
+            child: Align(
+              alignment: Alignment.center,
+              child: _buildCurrentPage(appState),
+            ),
+          ),
+        );
+
         return CupertinoPageScaffold(
           backgroundColor: AppColors.cream,
-          navigationBar: appState.showNavigationBar
+          navigationBar: (!isFullBleed && appState.showNavigationBar)
               ? CupertinoNavigationBar(
                   leading: Builder(
                     builder: (BuildContext context) {
@@ -223,25 +247,12 @@ class MyHomePage extends StatelessWidget {
                   ),
                 )
               : null,
-          child: SafeArea(
-            minimum: const EdgeInsets.all(20.0),
-            child: AnimatedSwitcher(
-              duration: const Duration(milliseconds: 500),
-              transitionBuilder:
-                  (Widget child, Animation<double> animation) {
-                    return FadeTransition(
-                      opacity: animation,
-                      child: child,
-                    );
-                  },
-              child: SizedBox.expand(
-                child: Align(
-                  alignment: Alignment.center,
-                  child: _buildCurrentPage(appState),
+          child: isFullBleed
+              ? pageContent
+              : SafeArea(
+                  minimum: const EdgeInsets.all(20.0),
+                  child: pageContent,
                 ),
-              ),
-            ),
-          ),
         );
       },
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'menu_screen.dart';
 import 'config_screen.dart';
 import 'exceptions_screen.dart';
 import 'home_screen.dart';
+import 'app_settings_screen.dart';
 import 'start_screen.dart';
 import 'household_income_summary_screen.dart';
 import 'expenses_screen.dart';
@@ -156,6 +157,9 @@ class MyHomePage extends StatelessWidget {
       case 'exceptions':
         screen = exceptionsScreen();
         break;
+      case 'app settings':
+        screen = appSettingsScreen();
+        break;
       case 'expenses':
         screen = expensesScreen();
         break;
@@ -200,7 +204,13 @@ class MyHomePage extends StatelessWidget {
     ];
     // Pages that own their own padding/safe-area + draw their own floating
     // nav button instead of relying on the top CupertinoNavigationBar.
-    const fullBleedPages = {'home', 'menu', 'config', 'exceptions'};
+    const fullBleedPages = {
+      'home',
+      'menu',
+      'config',
+      'exceptions',
+      'app settings',
+    };
 
     return Consumer<AppState>(
       builder: (context, appState, child) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -210,6 +210,10 @@ class MyHomePage extends StatelessWidget {
       'config',
       'exceptions',
       'app settings',
+      'start',
+      'household income summary',
+      'expenses',
+      'summary',
     };
 
     return Consumer<AppState>(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -200,7 +200,7 @@ class MyHomePage extends StatelessWidget {
     ];
     // Pages that own their own padding/safe-area + draw their own floating
     // nav button instead of relying on the top CupertinoNavigationBar.
-    const fullBleedPages = {'home', 'menu'};
+    const fullBleedPages = {'home', 'menu', 'config', 'exceptions'};
 
     return Consumer<AppState>(
       builder: (context, appState, child) {
@@ -225,17 +225,13 @@ class MyHomePage extends StatelessWidget {
               ? CupertinoNavigationBar(
                   leading: Builder(
                     builder: (BuildContext context) {
-                      IconData icon;
-                      if (flowPages.contains(appState.currentPage)) {
-                        icon = CupertinoIcons.bars;
-                      } else if (appState.currentPage == 'menu') {
-                        icon = CupertinoIcons.clear;
-                      } else if (appState.currentPage == 'config' ||
-                          appState.currentPage == 'exceptions') {
-                        icon = CupertinoIcons.back;
-                      } else {
-                        icon = CupertinoIcons.clear;
-                      }
+                      // Full-bleed pages (home, menu, config, exceptions,
+                      // app settings) draw their own floating navigation
+                      // button, so the only remaining icons here are the
+                      // menu opener on flow pages and the close fallback.
+                      final icon = flowPages.contains(appState.currentPage)
+                          ? CupertinoIcons.bars
+                          : CupertinoIcons.clear;
                       return CupertinoButton(
                         padding: EdgeInsets.zero,
                         child: Icon(icon),

--- a/lib/menu_screen.dart
+++ b/lib/menu_screen.dart
@@ -1,73 +1,78 @@
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
+
 import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
+
+class _MenuItem {
+  final String label;
+  final String route;
+  const _MenuItem(this.label, this.route);
+}
+
+const List<_MenuItem> _menuItems = [
+  _MenuItem('Config', 'config'),
+  _MenuItem('Exceptions', 'exceptions'),
+  _MenuItem('App Settings', 'app settings'),
+  _MenuItem('Update month', 'start'),
+];
 
 Widget menuScreen() {
-  return Consumer<AppState>(builder: (context, appState, child) {
-    return SizedBox.expand(
-      child: Column(
-        children: <Widget>[
-          const Spacer(),
-          CupertinoButton(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            color: CupertinoColors.activeBlue,
-            borderRadius: BorderRadius.circular(8.0),
-            child: const Text(
-              'Config',
-              style: TextStyle(
-                fontSize: 16.0,
-                color: CupertinoColors.white,
-              ),
-            ),
-            onPressed: () {
-              appState.navigateToPage('config');
-            },
-          ),
-          const SizedBox(height: 16.0),
-          CupertinoButton(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            color: CupertinoColors.activeBlue,
-            borderRadius: BorderRadius.circular(8.0),
-            child: const Text(
-              'Exceptions',
-              style: TextStyle(
-                fontSize: 16.0,
-                color: CupertinoColors.white,
-              ),
-            ),
-            onPressed: () {
-              appState.navigateToPage('exceptions');
-            },
-          ),
-
-          // light mode/dark mode switch
-          const Spacer(),
-          Padding(
-            padding: const EdgeInsets.all(0.0),
-            child: Center(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(CupertinoIcons.sun_max,
-                      color: CupertinoColors.systemYellow),
-                  CupertinoSwitch(
-                    value: appState.brightnessModeSwitchValue,
-                    activeTrackColor: CupertinoColors.systemGrey,
-                    inactiveTrackColor: CupertinoColors.systemYellow,
-                    onChanged: (bool value) {
-                      appState.toggleBrightnessMode();
-                    },
+  return Consumer<AppState>(
+    builder: (context, appState, _) {
+      return SafeArea(
+        child: Stack(
+          children: [
+            Column(
+              children: [
+                // Spacer matches the home screen's app-bar height so the
+                // visual rhythm stays consistent when toggling between them.
+                const SizedBox(height: 44),
+                Expanded(
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.lg - 4, // 20
+                        0,
+                        AppSpacing.lg - 4, // 20
+                        120, // clearance for floating close button
+                      ),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          for (var i = 0; i < _menuItems.length; i++) ...[
+                            if (i > 0) const SizedBox(height: 28),
+                            CupertinoButton(
+                              padding: EdgeInsets.zero,
+                              minimumSize: Size.zero,
+                              pressedOpacity: 0.5,
+                              onPressed: () =>
+                                  appState.navigateToPage(_menuItems[i].route),
+                              child: Text(
+                                _menuItems[i].label,
+                                style: AppText.menuItem(),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
                   ),
-                  const Icon(CupertinoIcons.moon,
-                      color: CupertinoColors.systemGrey),
-                ],
+                ),
+              ],
+            ),
+            Positioned(
+              left: AppSpacing.lg - 4, // 20
+              bottom: 28,
+              child: FloatingNavButton.close(
+                onPressed: appState.closeMenu,
               ),
             ),
-          ),
-        ],
-      ),
-    );
-  });
+          ],
+        ),
+      );
+    },
+  );
 }

--- a/lib/menu_screen.dart
+++ b/lib/menu_screen.dart
@@ -21,10 +21,10 @@ const List<_MenuItem> _menuItems = [
 Widget menuScreen() {
   return Consumer<AppState>(
     builder: (context, appState, _) {
-      return SafeArea(
-        child: Stack(
-          children: [
-            Column(
+      return Stack(
+        children: [
+          SafeArea(
+            child: Column(
               children: [
                 // Spacer matches the home screen's app-bar height so the
                 // visual rhythm stays consistent when toggling between them.
@@ -63,15 +63,15 @@ Widget menuScreen() {
                 ),
               ],
             ),
-            Positioned(
-              left: AppSpacing.lg - 4, // 20
-              bottom: 28,
-              child: FloatingNavButton.close(
-                onPressed: appState.closeMenu,
-              ),
+          ),
+          Positioned(
+            left: AppSpacing.lg - 4, // 20
+            bottom: AppSpacing.lg - 4, // 20
+            child: FloatingNavButton.close(
+              onPressed: appState.closeMenu,
             ),
-          ],
-        ),
+          ),
+        ],
       );
     },
   );

--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -249,7 +249,7 @@ class AppState extends ChangeNotifier {
         currentUserName = name;
         if (currentHouseholdId != null) {
           await getData();
-          navigateToPage('start');
+          navigateToPage('home');
         } else {
           await checkPendingInvite();
         }
@@ -304,7 +304,7 @@ class AppState extends ChangeNotifier {
   Future<void> checkPendingInvite() async {
     if (currentHouseholdId != null) {
       await getData();
-      navigateToPage('start');
+      navigateToPage('home');
       return;
     }
 
@@ -378,7 +378,7 @@ class AppState extends ChangeNotifier {
       }
 
       await getData();
-      navigateToPage('start');
+      navigateToPage('home');
     } finally {
       isBusy = false;
       notifyListeners();
@@ -882,6 +882,7 @@ class AppState extends ChangeNotifier {
   void handleMenuButtonPressed(icon) {
     const flowPages = [
       'signin',
+      'home',
       'start',
       'expenses',
       'summary',
@@ -897,6 +898,17 @@ class AppState extends ChangeNotifier {
     } else {
       icon = CupertinoIcons.clear;
     }
+    notifyListeners();
+  }
+
+  void openMenu() {
+    previousPage = currentPage;
+    currentPage = 'menu';
+    notifyListeners();
+  }
+
+  void closeMenu() {
+    currentPage = previousPage.isNotEmpty ? previousPage : 'home';
     notifyListeners();
   }
 

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -1,48 +1,81 @@
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
+
 import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
 
 Widget startScreen() {
   return Consumer<AppState>(builder: (context, appState, child) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        const Text(
-          'First, enter your total net income this month.',
-        ),
-        const Text(
-          '(This should be your entire "take-home" amount for the month, the amount that you bring home in your paycheck after taxes.)',
-          style: TextStyle(
-            fontSize: 12,
-            color: CupertinoColors.secondaryLabel,
+    return Stack(
+      children: [
+        SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.lg - 4, // 20
+                    AppSpacing.lg,
+                    AppSpacing.lg - 4, // 20
+                    120, // clearance for floating menu button
+                  ),
+                  child: Column(
+                    children: <Widget>[
+                      const Text(
+                        'First, enter your total net income this month.',
+                      ),
+                      const Text(
+                        '(This should be your entire "take-home" amount for the month, the amount that you bring home in your paycheck after taxes.)',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: CupertinoColors.secondaryLabel,
+                        ),
+                      ),
+                      CupertinoTextField(
+                        placeholder:
+                            'Enter ${appState.currentUserName}\'s net income',
+                        keyboardType: TextInputType.number,
+                        onChanged: (String value) {
+                          final parsed = double.tryParse(value);
+                          appState.updateTempCurrentUserNetIncomeCurrentMonth(
+                              parsed);
+                        },
+                      ),
+                      Container(
+                        margin: const EdgeInsets.only(top: 20.0),
+                        width: double.infinity,
+                        height: 50.0,
+                        decoration: BoxDecoration(
+                          color: CupertinoColors.activeBlue,
+                          borderRadius: BorderRadius.circular(25.0),
+                        ),
+                        child: CupertinoButton(
+                          padding: EdgeInsets.zero,
+                          child: const Text(
+                            'Next',
+                            style: TextStyle(color: CupertinoColors.white),
+                          ),
+                          onPressed: () {
+                            appState.updateHousematesIncome();
+                            appState
+                                .navigateToPage('household income summary');
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
-        CupertinoTextField(
-          placeholder: 'Enter ${appState.currentUserName}\'s net income',
-          keyboardType: TextInputType.number,
-          onChanged: (String value) {
-            final parsed = double.tryParse(value);
-            appState.updateTempCurrentUserNetIncomeCurrentMonth(parsed);
-          },
-        ),
-        Container(
-          margin: const EdgeInsets.only(top: 20.0),
-          width: double.infinity,
-          height: 50.0,
-          decoration: BoxDecoration(
-            color: CupertinoColors.activeBlue,
-            borderRadius: BorderRadius.circular(25.0),
-          ),
-          child: CupertinoButton(
-            padding: EdgeInsets.zero,
-            child: const Text(
-              'Next',
-              style: TextStyle(color: CupertinoColors.white),
-            ),
-            onPressed: () {
-              appState.updateHousematesIncome();
-              appState.navigateToPage('household income summary');
-            },
+        Positioned(
+          left: AppSpacing.lg - 4, // 20
+          bottom: AppSpacing.lg - 4, // 20
+          child: FloatingNavButton.menu(
+            onPressed: appState.openMenu,
           ),
         ),
       ],

--- a/lib/styles/app_styles.dart
+++ b/lib/styles/app_styles.dart
@@ -2,18 +2,66 @@ import 'package:flutter/cupertino.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class AppColors {
+  // Brand
   static const Color primaryGreen = Color(0xFF228B22);
   static const Color deepGreen = Color(0xFF196719);
   static const Color cream = Color(0xFFF9F5D2);
   static const Color ink = Color(0xFF1B1B1B);
   static const Color muted = Color(0xFF6B6B6B);
+
+  // Surfaces
+  static const Color surfaceWhite = Color(0xFFFFFFFF);
+  static const Color surfaceWarm = Color(0xFFFBF8DE);
+
+  // Hairlines / dividers
+  static const Color hairline = Color(0x141B1B1B); // rgba(27,27,27,0.08)
+  static const Color hairlineSoft = Color(0x0D1B1B1B); // rgba(27,27,27,0.05)
+
+  // Greens (tints)
+  static const Color green12 = Color(0x1F228B22); // rgba(34,139,34,0.12)
+  static const Color green08 = Color(0x14228B22); // rgba(34,139,34,0.08)
+
+  // Semantic balance colors
+  static const Color balancePositive = primaryGreen;
+  static const Color balanceNegative = Color(0xFFB83A2E);
+
+  // Neutrals
+  static const Color placeholderGray = Color(0xFFC0C0BC);
+}
+
+class AppShadows {
+  // Floating action button — green-tinted shadow on the primary-green hamburger.
+  // Mirrors design: 0 6px 18px rgba(25,103,25,0.28), 0 2px 4px rgba(25,103,25,0.18)
+  static const List<BoxShadow> fab = [
+    BoxShadow(
+      color: Color(0x47196719),
+      blurRadius: 18,
+      offset: Offset(0, 6),
+    ),
+    BoxShadow(
+      color: Color(0x2E196719),
+      blurRadius: 4,
+      offset: Offset(0, 2),
+    ),
+  ];
+
+  // Subtle 1px-equivalent shadow under cards.
+  // Mirrors design: 0 1px 0 rgba(27,27,27,0.04)
+  static const List<BoxShadow> card = [
+    BoxShadow(
+      color: Color(0x0A1B1B1B),
+      offset: Offset(0, 1),
+    ),
+  ];
 }
 
 class AppText {
-  static TextStyle title() {
+  // Modak display face. Used at multiple sizes — splash (50), in-app
+  // wordmark (26), section title (36 default).
+  static TextStyle title({double size = 36, Color? color}) {
     return GoogleFonts.modak(
-      fontSize: 36,
-      color: AppColors.primaryGreen,
+      fontSize: size,
+      color: color ?? AppColors.primaryGreen,
     );
   }
 
@@ -38,9 +86,127 @@ class AppText {
       color: AppColors.muted,
     );
   }
+
+  // Uppercase muted card-section header ("WHERE EVERYONE STANDS").
+  static TextStyle sectionLabel() {
+    return const TextStyle(
+      fontSize: 13,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.3,
+      color: AppColors.muted,
+    );
+  }
+
+  // Bold ink hero used for the home month label ("April 2026").
+  static TextStyle monthHeader() {
+    return const TextStyle(
+      fontSize: 28,
+      fontWeight: FontWeight.w700,
+      letterSpacing: -0.3,
+      color: AppColors.ink,
+      height: 1.1,
+    );
+  }
+
+  // Matrix column header label — the small "EXPENSE" cell.
+  static TextStyle tableColumnLabel() {
+    return const TextStyle(
+      fontSize: 11,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.4,
+      color: AppColors.muted,
+    );
+  }
+
+  // Matrix column header housemate name.
+  static TextStyle tableColumnName() {
+    return const TextStyle(
+      fontSize: 12,
+      fontWeight: FontWeight.w700,
+      color: AppColors.ink,
+      height: 1,
+    );
+  }
+
+  static TextStyle cardItemTitle() {
+    return const TextStyle(
+      fontSize: 15,
+      fontWeight: FontWeight.w600,
+      color: AppColors.ink,
+      height: 1.2,
+    );
+  }
+
+  static TextStyle cardItemSub() {
+    return const TextStyle(
+      fontSize: 12,
+      color: AppColors.muted,
+      height: 1.2,
+    );
+  }
+
+  // Per-cell amount in the expense × person matrix.
+  static TextStyle tableCell({Color? color}) {
+    return TextStyle(
+      fontSize: 13,
+      fontWeight: FontWeight.w500,
+      color: color ?? AppColors.ink,
+      letterSpacing: -0.1,
+      fontFeatures: const [FontFeature.tabularFigures()],
+    );
+  }
+
+  static TextStyle tableTotalLabel() {
+    return const TextStyle(
+      fontSize: 13,
+      fontWeight: FontWeight.w700,
+      color: AppColors.ink,
+      letterSpacing: 0.1,
+    );
+  }
+
+  static TextStyle tableTotalValue() {
+    return const TextStyle(
+      fontSize: 14,
+      fontWeight: FontWeight.w700,
+      color: AppColors.deepGreen,
+      letterSpacing: -0.2,
+      fontFeatures: [FontFeature.tabularFigures()],
+    );
+  }
+
+  static TextStyle balancePill({required Color color}) {
+    return TextStyle(
+      fontSize: 13,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.1,
+      color: color,
+    );
+  }
+
+  // Footnotes outside cards (the exception line under the matrix).
+  static TextStyle microCaption() {
+    return const TextStyle(
+      fontSize: 11,
+      color: AppColors.muted,
+      height: 1.4,
+    );
+  }
+
+  // Plain-text headline used as a tappable menu item — system font, not Modak.
+  static TextStyle menuItem() {
+    return const TextStyle(
+      fontSize: 36,
+      fontWeight: FontWeight.w700,
+      letterSpacing: -0.5,
+      color: AppColors.ink,
+      height: 1.1,
+    );
+  }
 }
 
 class AppSpacing {
+  static const double xxs = 4;
   static const double xs = 8;
   static const double sm = 12;
   static const double md = 16;

--- a/lib/summary_screen.dart
+++ b/lib/summary_screen.dart
@@ -1,25 +1,58 @@
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
+
 import 'providers/app_state.dart';
+import 'styles/app_styles.dart';
+import 'widgets/floating_nav_button.dart';
 
 Widget summaryScreen() {
   return Consumer<AppState>(builder: (context, appState, child) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        const Text('Summary'),
-        for (var housemate in appState.housemates)
-          Padding(
-            padding: const EdgeInsets.only(top: 20.0),
-            child: Column(
-              children: <Widget>[
-                Text('${housemate['name']}\'s share of expenses:'),
-                for (var i = 0; i < housemate['shareOfExpenses'].length; i++)
-                  Text(
-                      '${housemate['shareOfExpenses'][i]['name']}: \$${housemate['shareOfExpenses'][i]['amount'].toStringAsFixed(2)}'),
-              ],
-            ),
+    return Stack(
+      children: [
+        SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.lg - 4, // 20
+                    AppSpacing.lg,
+                    AppSpacing.lg - 4, // 20
+                    120, // clearance for floating menu button
+                  ),
+                  child: Column(
+                    children: <Widget>[
+                      const Text('Summary'),
+                      for (var housemate in appState.housemates)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 20.0),
+                          child: Column(
+                            children: <Widget>[
+                              Text(
+                                  '${housemate['name']}\'s share of expenses:'),
+                              for (var i = 0;
+                                  i < housemate['shareOfExpenses'].length;
+                                  i++)
+                                Text(
+                                    '${housemate['shareOfExpenses'][i]['name']}: \$${housemate['shareOfExpenses'][i]['amount'].toStringAsFixed(2)}'),
+                            ],
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ),
+        ),
+        Positioned(
+          left: AppSpacing.lg - 4, // 20
+          bottom: AppSpacing.lg - 4, // 20
+          child: FloatingNavButton.menu(
+            onPressed: appState.openMenu,
+          ),
+        ),
       ],
     );
   });

--- a/lib/widgets/floating_nav_button.dart
+++ b/lib/widgets/floating_nav_button.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/cupertino.dart';
+
+import '../styles/app_styles.dart';
+
+/// A 56×56 circular nav button positioned by the caller (typically
+/// `Positioned(left: 20, bottom: 28, ...)`). Three intent-named variants:
+///
+///  - `FloatingNavButton.menu` — primary-green disc, white bars glyph, soft
+///    green-tinted shadow. Opens a menu/overlay.
+///  - `FloatingNavButton.close` — plain ink ×, no disc. Closes a menu/overlay.
+///  - `FloatingNavButton.back` — cream disc, deep-green outline, deep-green
+///    back arrow. Navigates back to a parent screen.
+class FloatingNavButton extends StatefulWidget {
+  final _FloatingNavButtonStyle _style;
+  final VoidCallback onPressed;
+  final String semanticLabel;
+
+  const FloatingNavButton._({
+    required _FloatingNavButtonStyle style,
+    required this.onPressed,
+    required this.semanticLabel,
+  }) : _style = style;
+
+  factory FloatingNavButton.menu({required VoidCallback onPressed}) {
+    return FloatingNavButton._(
+      style: _FloatingNavButtonStyle.menu,
+      onPressed: onPressed,
+      semanticLabel: 'Open menu',
+    );
+  }
+
+  factory FloatingNavButton.close({required VoidCallback onPressed}) {
+    return FloatingNavButton._(
+      style: _FloatingNavButtonStyle.close,
+      onPressed: onPressed,
+      semanticLabel: 'Close menu',
+    );
+  }
+
+  factory FloatingNavButton.back({required VoidCallback onPressed}) {
+    return FloatingNavButton._(
+      style: _FloatingNavButtonStyle.back,
+      onPressed: onPressed,
+      semanticLabel: 'Back',
+    );
+  }
+
+  @override
+  State<FloatingNavButton> createState() => _FloatingNavButtonState();
+}
+
+enum _FloatingNavButtonStyle { menu, close, back }
+
+class _FloatingNavButtonState extends State<FloatingNavButton> {
+  bool _pressed = false;
+
+  void _setPressed(bool value) {
+    if (_pressed == value) return;
+    setState(() => _pressed = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final style = widget._style;
+    final pressedOpacity = style == _FloatingNavButtonStyle.close ? 0.5 : 0.65;
+
+    return Semantics(
+      button: true,
+      label: widget.semanticLabel,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapDown: (_) => _setPressed(true),
+        onTapUp: (_) => _setPressed(false),
+        onTapCancel: () => _setPressed(false),
+        onTap: widget.onPressed,
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 120),
+          opacity: _pressed ? pressedOpacity : 1.0,
+          child: SizedBox(
+            width: 56,
+            height: 56,
+            child: _buildVisual(style),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVisual(_FloatingNavButtonStyle style) {
+    switch (style) {
+      case _FloatingNavButtonStyle.menu:
+        return Container(
+          decoration: const BoxDecoration(
+            shape: BoxShape.circle,
+            color: AppColors.primaryGreen,
+            boxShadow: AppShadows.fab,
+          ),
+          alignment: Alignment.center,
+          child: const _BarsIcon(
+            color: AppColors.surfaceWhite,
+            size: 24,
+          ),
+        );
+      case _FloatingNavButtonStyle.close:
+        // Plain ink × — no disc, no shadow.
+        return const Center(
+          child: _CloseIcon(
+            color: AppColors.ink,
+            size: 26,
+            strokeWidth: 2.2,
+          ),
+        );
+      case _FloatingNavButtonStyle.back:
+        return Container(
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: AppColors.cream,
+            border: Border.all(
+              color: AppColors.deepGreen,
+              width: 2,
+            ),
+          ),
+          alignment: Alignment.center,
+          child: const _BackChevron(
+            color: AppColors.deepGreen,
+            size: 22,
+            strokeWidth: 2.4,
+          ),
+        );
+    }
+  }
+}
+
+class _BarsIcon extends StatelessWidget {
+  final Color color;
+  final double size;
+
+  const _BarsIcon({required this.color, required this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: Size.square(size),
+      painter: _BarsPainter(color: color),
+    );
+  }
+}
+
+class _BarsPainter extends CustomPainter {
+  final Color color;
+
+  _BarsPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = 2.0
+      ..style = PaintingStyle.stroke;
+
+    // Three horizontal lines at y = 7, 12, 17 of a 24-grid.
+    final scale = size.width / 24.0;
+    void line(double yUnits) {
+      final y = yUnits * scale;
+      canvas.drawLine(
+        Offset(4 * scale, y),
+        Offset(20 * scale, y),
+        paint,
+      );
+    }
+
+    line(7);
+    line(12);
+    line(17);
+  }
+
+  @override
+  bool shouldRepaint(_BarsPainter oldDelegate) => oldDelegate.color != color;
+}
+
+class _CloseIcon extends StatelessWidget {
+  final Color color;
+  final double size;
+  final double strokeWidth;
+
+  const _CloseIcon({
+    required this.color,
+    required this.size,
+    required this.strokeWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: Size.square(size),
+      painter: _ClosePainter(color: color, strokeWidth: strokeWidth),
+    );
+  }
+}
+
+class _ClosePainter extends CustomPainter {
+  final Color color;
+  final double strokeWidth;
+
+  _ClosePainter({required this.color, required this.strokeWidth});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke;
+
+    // Two diagonal lines, 6→18 in a 24-grid.
+    final scale = size.width / 24.0;
+    canvas.drawLine(
+      Offset(6 * scale, 6 * scale),
+      Offset(18 * scale, 18 * scale),
+      paint,
+    );
+    canvas.drawLine(
+      Offset(18 * scale, 6 * scale),
+      Offset(6 * scale, 18 * scale),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_ClosePainter oldDelegate) =>
+      oldDelegate.color != color || oldDelegate.strokeWidth != strokeWidth;
+}
+
+class _BackChevron extends StatelessWidget {
+  final Color color;
+  final double size;
+  final double strokeWidth;
+
+  const _BackChevron({
+    required this.color,
+    required this.size,
+    required this.strokeWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: Size.square(size),
+      painter: _BackChevronPainter(color: color, strokeWidth: strokeWidth),
+    );
+  }
+}
+
+class _BackChevronPainter extends CustomPainter {
+  final Color color;
+  final double strokeWidth;
+
+  _BackChevronPainter({required this.color, required this.strokeWidth});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke;
+
+    // < shape with vertices (15,6) → (9,12) → (15,18) on a 24-grid.
+    final scale = size.width / 24.0;
+    final path = Path()
+      ..moveTo(15 * scale, 6 * scale)
+      ..lineTo(9 * scale, 12 * scale)
+      ..lineTo(15 * scale, 18 * scale);
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_BackChevronPainter oldDelegate) =>
+      oldDelegate.color != color || oldDelegate.strokeWidth != strokeWidth;
+}


### PR DESCRIPTION
## Summary

Implements the [Tally Home design handoff](https://api.anthropic.com/v1/design/h/LDMHv7wavnKUNvNPflKU5w?open_file=Tally+Home.html) from Claude Design. Introduces a true post-signin **Home** view of household financial state, redesigns the **Menu** as plain-text headlines, and replaces the old top-nav-bar leading icons with **floating bottom-left buttons** (one for each navigation intent).

- **Home screen** — new default view after signin: top app bar (Modak wordmark + household name), big month header, "Where everyone stands" balance card with paid/owed pills, expense × person matrix with totals row, exception footnote.
- **Menu screen** — restyled to four plain-text items in a centered, left-aligned column: Config, Exceptions, App Settings, Update month.
- **App Settings screen** — new screen housing the brightness toggle that previously lived as a footer on the menu.
- **Entry-flow screens get the menu button** — `start`, `household income summary`, `expenses`, and `summary` (reached via Menu → Update month) now have a `FloatingNavButton.menu` so the user can always reach the menu from those screens.
- **Floating navigation buttons** — three intent-named variants in a shared widget: `.menu` (primary-green disc), `.close` (plain ink ×, no disc), `.back` (cream fill + deep-green outline + deep-green ←). Replaces the dormant top-nav-bar leading icons everywhere.
- **Anchored to screen corner with equal margins** — buttons sit at `left: 20, bottom: 20` measured from the actual screen edges (not from inside the SafeArea), so the distance from the button to the left bezel matches the distance to the bottom bezel.
- **iOS UIScene plugin registration fix** — Flutter 3.41 made UIScene the default lifecycle; the implicit engine is now created later in the scene lifecycle. Plugin registration moved from `application:didFinishLaunchingWithOptions:` to `didInitializeImplicitFlutterEngine(_:)`. Without this, the text-input plugin wasn't wiring up, which manifested as the iOS keyboard never appearing on TextField focus (signin screen unusable).
- **Centralized design tokens** — all new colors, shadows, text styles, and the `xxs` spacing live in `lib/styles/app_styles.dart`. No magic numbers in screen files.
- **Routing** — post-signin destination changed from `start` to `home`; the existing entry flow (`start → household income summary → expenses → summary`) is now reachable via the menu's **Update month** item.

### Layout structure (applied to all 9 screens with floating nav buttons)

```dart
return Stack(
  children: [
    SafeArea(
      child: Column(
        crossAxisAlignment: CrossAxisAlignment.stretch,
        children: [Expanded(child: SingleChildScrollView(...))],
      ),
    ),
    Positioned(left: 20, bottom: 20, child: FloatingNavButton...),
  ],
);
```

The outer `Stack` lets the `Positioned` measure from the actual screen edges; the inner `Column > Expanded` forces the layout to fill the screen even when content is short, so the button always sits in the same corner regardless of content length.

### Data binding

Home reads household name, housemate names/initials, and expense names/amounts from `AppState` when present; falls back to the design's sample household when those are empty. The `paid` per housemate and `paidBy` per expense fields don't yet exist in the schema, so they're mocked with a clear TODO comment to wire to real data once added.

### Visual verification

Confirmed on the iPhone 17 Simulator (`npm run run:local`) by routing directly to each new screen and walking the entry flow:

- Home — wordmark, household name, month header, balance card, expense matrix, totals row, exception footnote, floating green hamburger ✓
- Menu — 4 plain-text items, centered + left-aligned column, plain ink × at bottom-left ✓
- App Settings — APPEARANCE section, white card with sun/switch/moon row, cream-with-green-outline back button ✓
- Config — content + cream-with-green-outline back button ✓ (Exceptions matches the same pattern)
- Start / Income summary / Expenses / Summary — floating green hamburger at bottom-left, opens Menu, can return via Update month ✓
- Signin TextField focus → iOS keyboard appears (post-AppDelegate fix) ✓

`flutter analyze` — no new issues introduced. Pre-existing lints in unrelated files are untouched.

## Files

| New | Modified |
|-----|----------|
| `lib/home_screen.dart` | `lib/main.dart` — register routes, full-bleed branch (incl. entry-flow screens) |
| `lib/app_settings_screen.dart` | `lib/menu_screen.dart` — full restyle, anchored close button |
| `lib/widgets/floating_nav_button.dart` | `lib/config_screen.dart` — floating back button, anchored |
|   | `lib/exceptions_screen.dart` — floating back button, anchored |
|   | `lib/start_screen.dart` — floating menu button |
|   | `lib/household_income_summary_screen.dart` — floating menu button |
|   | `lib/expenses_screen.dart` — floating menu button |
|   | `lib/summary_screen.dart` — floating menu button |
|   | `lib/providers/app_state.dart` — `openMenu`/`closeMenu`, post-signin → home |
|   | `lib/styles/app_styles.dart` — token additions |
|   | `ios/Runner/AppDelegate.swift` — UIScene plugin registration |

## Commits

1. `64b7c67` — Add Tally home screen as the post-signin landing view
2. `288971c` — Redesign menu screen with plain-text items and floating close button
3. `1e3543a` — Replace top-nav back arrows with floating back button
4. `8f09068` — Add App Settings screen with brightness toggle moved from menu
5. `6f6c317` — Anchor floating nav buttons at screen bottom-left across all screens
6. `c13b218` — Move iOS plugin registration to `didInitializeImplicitFlutterEngine`

## Test plan

- [ ] `flutter analyze` is clean (no new issues from this branch)
- [ ] Sign in with the seeded test phone (`+16025459712` / OTP `123456`) — TextField accepts input, OTP verifies, lands on Home
- [ ] Tap floating hamburger → Menu fades in; verify 4 items + plain ink × at the same coordinates
- [ ] Tap × → returns to Home
- [ ] Tap each menu item:
  - [ ] Config → cream-outlined back button → tap → returns to Menu
  - [ ] Exceptions → same back behavior
  - [ ] App Settings → toggle dark/light mode → back button returns to Menu
  - [ ] Update month → walks `start → household income summary → expenses → summary`; floating menu button is reachable from every step and returns to the menu
- [ ] On every screen with a floating button, the distance from the button to the left bezel and to the bottom bezel look equal
- [ ] Resize / rotate / dark-mode pass to confirm cream canvas + tokens still read correctly