### PR TITLE
Fix Config & Exceptions screens crashing on open

### DIFF
--- a/lib/config_screen.dart
+++ b/lib/config_screen.dart
@@ -28,7 +28,10 @@ Widget configScreen() {
                       for (var housemate in appState.housemates)
                         Row(
                           children: <Widget>[
-                            Text(housemate['name']),
+                            Text((housemate['display_name'] ??
+                                    housemate['name'] ??
+                                    'Unnamed')
+                                .toString()),
                             CupertinoButton(
                               padding: EdgeInsets.zero,
                               child: const Icon(CupertinoIcons.delete),
@@ -68,7 +71,10 @@ Widget configScreen() {
                       for (var expense in appState.expenses)
                         Row(
                           children: <Widget>[
-                            Text(expense['name']),
+                            Text((expense['description'] ??
+                                    expense['name'] ??
+                                    'Unnamed')
+                                .toString()),
                             CupertinoButton(
                               padding: EdgeInsets.zero,
                               child: const Icon(CupertinoIcons.delete),

--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -764,9 +764,29 @@ class AppState extends ChangeNotifier {
     }
     final data = await supabase
         .from('exceptions')
-        .select()
+        .select('id, user_id, category_id, exception_type, percent,'
+            ' household_id, users(display_name), categories(name)')
         .eq('household_id', currentHouseholdId!);
-    exceptions = data;
+    // Project rows into the legacy shape the exceptions UI expects:
+    // `name`, `category`, `type` keys plus a numeric `percent`.
+    exceptions = (data as List).map<Map<String, dynamic>>((row) {
+      final user = row['users'] as Map?;
+      final category = row['categories'] as Map?;
+      final rawPercent = row['percent'];
+      final percent = rawPercent is num
+          ? rawPercent
+          : double.tryParse(rawPercent?.toString() ?? '') ?? 0;
+      return {
+        'id': row['id'],
+        'user_id': row['user_id'],
+        'category_id': row['category_id'],
+        'household_id': row['household_id'],
+        'name': user?['display_name'],
+        'category': category?['name'],
+        'type': row['exception_type'],
+        'percent': percent,
+      };
+    }).toList();
   }
 
   // unsaved exceptions have an additional "edited" key to track if they have been edited for UI purposes. Separated from the regular exceptions to allow for reverting changes.


### PR DESCRIPTION
## Summary
- Both screens were reading field names that don't exist in the Supabase schema (`housemate['name']`, `expense['name']`, `exception['name'/'category'/'type']`), so `Text(...)` got null and threw `type 'Null' is not a subtype of type 'String'` on open.
- `lib/config_screen.dart`: read `display_name` / `description` defensively (with the legacy `name` key as a fallback for any locally-added items).
- `lib/providers/app_state.dart` `getExceptions()`: select with `users(display_name)` and `categories(name)` embeds, then project each row into the legacy shape (`name`, `category`, `type`) the exceptions UI and `unsavedExceptions` flow expect. Also coerce `percent` to a `num` since Postgres `numeric` comes back as a string.

## Test plan
- [x] `flutter analyze` clean (no new warnings)
- [x] Reproduced the original crash on the simulator with the prior build
- [x] Fresh `flutter run`, signed in via cached session, opened menu → Config: housemates ("Alex", "Joel") and all 8 expense descriptions render
- [x] Menu → Exceptions: renders the seed exception correctly — "Alex pays 75.00% of their normal Rent charge."